### PR TITLE
Drop Kotlin/JS extensions and use internal `jso` instead

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 implementation(project(":external"))
-                implementation(libs.kotlin.extensions)
             }
         }
 

--- a/core/src/jsMain/kotlin/Key.kt
+++ b/core/src/jsMain/kotlin/Key.kt
@@ -1,7 +1,6 @@
 package com.juul.indexeddb
 
 import com.juul.indexeddb.external.IDBKeyRange
-import kotlinext.js.jso
 import kotlin.js.Date
 
 private fun Array<dynamic>.validateKeyTypes() {

--- a/core/src/jsMain/kotlin/Transaction.kt
+++ b/core/src/jsMain/kotlin/Transaction.kt
@@ -3,7 +3,6 @@ package com.juul.indexeddb
 import com.juul.indexeddb.external.IDBCursor
 import com.juul.indexeddb.external.IDBRequest
 import com.juul.indexeddb.external.IDBTransaction
-import kotlinext.js.jso
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow

--- a/core/src/jsMain/kotlin/jso.kt
+++ b/core/src/jsMain/kotlin/jso.kt
@@ -1,0 +1,9 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.juul.indexeddb
+
+// Copied from:
+// https://github.com/JetBrains/kotlin-wrappers/blob/91b2c1568ec6f779af5ec10d89b5e2cbdfe785ff/kotlin-extensions/src/main/kotlin/kotlinx/js/jso.kt
+
+internal inline fun <T : Any> jso(): T = js("({})")
+internal inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)

--- a/core/src/jsTest/kotlin/KeyTests.kt
+++ b/core/src/jsTest/kotlin/KeyTests.kt
@@ -1,7 +1,6 @@
 package com.juul.indexeddb
 
 import com.juul.indexeddb.external.IDBKeyRange
-import kotlinext.js.jso
 import kotlin.js.Date
 import kotlin.test.Test
 import kotlin.test.assertFails

--- a/core/src/jsTest/kotlin/Samples.kt
+++ b/core/src/jsTest/kotlin/Samples.kt
@@ -1,6 +1,5 @@
 package com.juul.indexeddb
 
-import kotlinext.js.jso
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlin.test.Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,9 @@
 [versions]
 coroutines = "1.6.0"
-extensions = "1.0.1-pre.304-kotlin-1.6.10"
 kotlin = "1.6.10"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlin-extensions = { module = "org.jetbrains.kotlin-wrappers:kotlin-extensions", version.ref = "extensions" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version = "1.6.10" }


### PR DESCRIPTION
Removes [Kotlin/JS extension] dependency in favor of using internal `jso` functions.
The [Kotlin/JS extension] library is upgraded frequently and has had breaking API changes, which would occasionally cause build failures for library consumers who also pulled in mismatched versions of [Kotlin/JS extension].

[Kotlin/JS extension]: https://github.com/JetBrains/kotlin-wrappers/tree/master/kotlin-extensions