### PR TITLE
Remove deprecated Gradle option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-# https://kotlinlang.org/docs/reference/migrating-multiplatform-project-to-14.html#try-the-hierarchical-project-structure
-kotlin.mpp.enableGranularSourceSetsMetadata=true
-
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Publication configuration


### PR DESCRIPTION
This option was deprecated in Kotlin 1.6.20 per [release announcement](https://kotlinlang.org/docs/whatsnew1620.html#hierarchical-structure-support-for-multiplatform-projects).