### PR TITLE
Configure release drafter for automatic versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,10 +1,8 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
 categories:
-  - title: 'Android'
-    label: 'android'
-  - title: 'Apple'
-    label: 'apple'
-  - title: 'JavaScript'
-    label: 'javascript'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
   - title: '🧰 Maintenance'
     labels:
       - 'maintenance'
@@ -12,7 +10,15 @@ categories:
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'
-template: |
-  ## 🚀 Changes
-  
-  $CHANGES
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Configures release drafter to pick the appropriate version number based on PRs being labeled as `patch`, `minor`, or `major`.

Dropped platform categories since IndexedDB is JavaScript only.