### PR TITLE
reproducer: cursor moves forward in collect block

### DIFF
--- a/reproducer/build.gradle.kts
+++ b/reproducer/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    js(IR) {
+        binaries.executable()
+        browser()
+    }
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(libs.coroutines.core)
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+                implementation(project(":core"))
+            }
+        }
+    }
+}

--- a/reproducer/src/jsMain/kotlin/reproducer/Main.kt
+++ b/reproducer/src/jsMain/kotlin/reproducer/Main.kt
@@ -1,0 +1,59 @@
+package reproducer
+
+import com.juul.indexeddb.Key
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.openDatabase
+import kotlinx.browser.window
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlin.js.Date
+
+fun main() {
+    window.onload = {
+        MainScope().launch {
+            val database = openDatabase("test", 1) { database, old, new ->
+                if (old < 1) {
+                    database.createObjectStore("store", KeyPath("id"))
+                }
+            }
+            database.writeTransaction("store") {
+                val store = objectStore("store")
+                store.clear()
+                store.add(jso<Data> { id = 0; name = "a" })
+                store.add(jso<Data> { id = 1; name = "b" })
+                store.add(jso<Data> { id = 2; name = "c" })
+                store.add(jso<Data> { id = 3; name = "d" })
+                store.add(jso<Data> { id = 4; name = "e" })
+                store.add(jso<Data> { id = 5; name = "f" })
+                store.add(jso<Data> { id = 6; name = "g" })
+                store.add(jso<Data> { id = 7; name = "h" })
+                store.add(jso<Data> { id = 8; name = "i" })
+                store.add(jso<Data> { id = 9; name = "j" })
+            }
+            database.writeTransaction("store") {
+                val store = objectStore("store")
+                store.openCursor()
+                    .collect { cursor ->
+                        console.log("1: cursor.value = ${JSON.stringify(cursor.value, null, "  ")}")
+                        console.log("2: delete()")
+                        cursor.delete()
+                        console.log("3: cursor.value = ${JSON.stringify(cursor.value, null, "  ")}")
+                        console.log("4: store.get()")
+                        store.get(Key("other"))
+                        console.log("5: cursor.value = ${JSON.stringify(cursor.value, null, "  ")}")
+                        console.log("6: store.get()")
+                        store.get(Key("other"))
+                        console.log("7: cursor.value = ${JSON.stringify(cursor.value, null, "  ")}")
+                    }
+            }
+        }
+    }
+}
+
+fun <T : Any> jso(): T = js("({})") as T
+inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)
+
+external interface Data {
+    var id: Int
+    var name: String
+}

--- a/reproducer/src/jsMain/resources/index.html
+++ b/reproducer/src/jsMain/resources/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>reproducer</title>
+</head>
+<body>
+<script src="reproducer.js"></script>
+</body>
+</html>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,4 +11,5 @@ pluginManagement {
 include(
     "core",
     "external",
+    "reproducer"
 )


### PR DESCRIPTION
This is a reproducer.

## Run

Run in a browser by `./gradlew :reproducer:jsBrowserDevelopmentRun`

## Code



## Output

console log:

```
1: cursor.value = {
  "id": 0,
  "name": "a"
}
2: delete()
3: cursor.value = {
  "id": 0,
  "name": "a"
}
4: store.get()
5: cursor.value = {
  "id": 1,
  "name": "b"
}
6: store.get()
7: cursor.value = {
  "id": 2,
  "name": "c"
}
1: cursor.value = {
  "id": 2,
  "name": "c"
}
2: delete()
CoroutineExceptionHandlerImpl.kt?59a9:11 DOMException: Failed to execute 'delete' on 'IDBCursor': The cursor is being iterated or has iterated past its end.
    at WriteTransaction.delete_t3salm_k$ (webpack-internal:///./kotlin/indexeddb-core.js:1097:48)
    at main$lambda$slambda$slambda$slambda.doResume_5yljmg_k$ (webpack-internal:///./kotlin/indexeddb-reproducer.js:97:59)
    at main$lambda$slambda$slambda$slambda.invoke_cb6tvv_k$ (webpack-internal:///./kotlin/indexeddb-reproducer.js:81:16)
    at sam$kotlinx_coroutines_flow_FlowCollector$0.l [as function_1] (webpack-internal:///./kotlin/indexeddb-reproducer.js:151:16)
    at sam$kotlinx_coroutines_flow_FlowCollector$0.emit_1fbrsb_k$ (webpack-internal:///./kotlin/indexeddb-reproducer.js:69:17)
    at $emitAllImplCOROUTINE$4.doResume_5yljmg_k$ (webpack-internal:///./kotlin/kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js:8063:51)
    at CoroutineImpl.resumeWith_7onugl_k$ (webpack-internal:///./kotlin/kotlin-kotlin-stdlib-js-ir.js:16089:33)
    at CoroutineImpl.resumeWith_s3a3yh_k$ (webpack-internal:///./kotlin/kotlin-kotlin-stdlib-js-ir.js:16135:17)
    at resume (webpack-internal:///./kotlin/kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js:9405:50)
    at resumeUnconfined (webpack-internal:///./kotlin/kotlinx.coroutines-kotlinx-coroutines-core-js-ir.js:9362:9)
```

![image](https://user-images.githubusercontent.com/1311446/198882347-59297d21-93be-4bee-89ce-f451320d7b16.png)
