### PR TITLE
Add only() method for creating Key instance

### DIFF
--- a/core/src/jsMain/kotlin/Key.kt
+++ b/core/src/jsMain/kotlin/Key.kt
@@ -59,5 +59,5 @@ public fun bound(
 ): Key = Key(IDBKeyRange.bound(x, y, lowerOpen, upperOpen))
 
 public fun only(
-    z: dynamic
+    z: dynamic,
 ): Key = Key(IDBKeyRange.only(z))

--- a/core/src/jsMain/kotlin/Key.kt
+++ b/core/src/jsMain/kotlin/Key.kt
@@ -57,3 +57,7 @@ public fun bound(
     lowerOpen: Boolean = false,
     upperOpen: Boolean = false,
 ): Key = Key(IDBKeyRange.bound(x, y, lowerOpen, upperOpen))
+
+public fun only(
+    z: dynamic
+): Key = Key(IDBKeyRange.only(z))


### PR DESCRIPTION
Adds only() method to create `only` Key.

usage

```
store.openCursor(only(...)).collect {
    ...
}
```

Though `openCursor(only(...))` is almost same as `openCursor(Key(...))`, It's confusing if only() method is absent.