### PR TITLE
Allow for manual cursor control

### DIFF
--- a/core/src/jsMain/kotlin/Cursor.kt
+++ b/core/src/jsMain/kotlin/Cursor.kt
@@ -12,6 +12,22 @@ public open class Cursor internal constructor(
     public val primaryKey: dynamic
         get() = cursor.primaryKey
 
+    public fun `continue`() {
+        cursor.`continue`()
+    }
+
+    public fun advance(count: Int) {
+        cursor.advance(count)
+    }
+
+    public fun `continue`(key: Key) {
+        cursor.`continue`(key.toJs())
+    }
+
+    public fun continuePrimaryKey(key: Key, primaryKey: Key) {
+        cursor.continuePrimaryKey(key.toJs(), primaryKey.toJs())
+    }
+
     public enum class Direction(internal val constant: String) {
         Next("next"),
         NextUnique("nextunique"),

--- a/core/src/jsTest/kotlin/Samples.kt
+++ b/core/src/jsTest/kotlin/Samples.kt
@@ -54,7 +54,7 @@ class Samples {
         val charlie = database.transaction("customers") {
             objectStore("customers")
                 .index("name")
-                .openCursor()
+                .openCursor(autoContinue = true)
                 .map { it.value as Customer }
                 .first { it.age < 32 }
         }
@@ -73,7 +73,7 @@ class Samples {
         val skipTwoYoungest = database.transaction("customers") {
             objectStore("customers")
                 .index("age")
-                .openCursor(cursorStart = CursorStart.Advance(2))
+                .openCursor(cursorStart = CursorStart.Advance(2), autoContinue = true)
                 .map { it.value as Customer }
                 .map { it.name }
                 .toList()
@@ -83,7 +83,7 @@ class Samples {
         val skipUntil33 = database.transaction("customers") {
             objectStore("customers")
                 .index("age")
-                .openCursor(cursorStart = CursorStart.Continue(Key(33)))
+                .openCursor(cursorStart = CursorStart.Continue(Key(33)), autoContinue = true)
                 .map { it.value as Customer }
                 .map { it.name }
                 .toList()


### PR DESCRIPTION
@irgaly this should fix the issue you've shown in #75, although it'll require two changes to your code:
- The `openCursor()` call needs to add an `autoContinue = false` parameter
- You'll need to manually call ``cursor.`continue`()`` at the end of your `collect` block.

Closes #75.