### PR TITLE
Add support for out-of-line keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 .DS_Store
 local.properties
+yarn.lock

--- a/core/src/jsTest/kotlin/AutoIncrementKeyObjectStore.kt
+++ b/core/src/jsTest/kotlin/AutoIncrementKeyObjectStore.kt
@@ -1,0 +1,30 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AutoIncrementKeyObjectStore {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("auto-increment-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", AutoIncrement)
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("auto-increment-keys")
+        }
+
+        val id = database.writeTransaction("users") {
+            objectStore("users").add(jso { username = "Username" }) as Double
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key(id))
+        }
+        assertEquals("Username", user.username)
+    }
+}

--- a/core/src/jsTest/kotlin/InLineKeyObjectStore.kt
+++ b/core/src/jsTest/kotlin/InLineKeyObjectStore.kt
@@ -1,0 +1,30 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InLineKeyObjectStore {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("in-line-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", KeyPath("id"))
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("in-line-keys")
+        }
+
+        database.writeTransaction("users") {
+            objectStore("users").add(jso { id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a"; username = "Username" })
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a"))
+        }
+        assertEquals("Username", user.username)
+    }
+}

--- a/core/src/jsTest/kotlin/OutOfLineKeyObjectStore.kt
+++ b/core/src/jsTest/kotlin/OutOfLineKeyObjectStore.kt
@@ -1,0 +1,30 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OutOfLineKeyObjectStore {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("out-of-line-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users")
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("out-of-line-keys")
+        }
+
+        database.writeTransaction("users") {
+            objectStore("users").add(jso { username = "Username" }, Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a"))
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a"))
+        }
+        assertEquals("Username", user.username)
+    }
+}

--- a/external/src/jsMain/kotlin/IDBDatabase.kt
+++ b/external/src/jsMain/kotlin/IDBDatabase.kt
@@ -8,6 +8,7 @@ public external class IDBDatabase : EventTarget {
     public val version: Int
     public val objectStoreNames: Array<String>
     public fun close()
+    public fun createObjectStore(name: String): IDBObjectStore
     public fun createObjectStore(name: String, options: dynamic): IDBObjectStore
     public fun deleteObjectStore(name: String)
     public fun transaction(storeNames: Array<String>, mode: String): IDBTransaction


### PR DESCRIPTION
Thanks to @Ayfri for making me aware of this deficiency. Closes #78

Strictly speaking this is a breaking change because of the changed return type on `add`/`put` (from `Unit` to `dynamic`), but in practice it shouldn't break much. Labeled as major regardless.