### PR TITLE
Add deleteIndex method

### DIFF
--- a/core/src/jsMain/kotlin/Transaction.kt
+++ b/core/src/jsMain/kotlin/Transaction.kt
@@ -316,4 +316,8 @@ public class VersionChangeTransaction internal constructor(
 
     public fun ObjectStore.createIndex(name: String, keyPath: KeyPath, unique: Boolean): Index =
         Index(objectStore.createIndex(name, keyPath.toUnwrappedJs(), jso { this.unique = unique }))
+
+    public fun ObjectStore.deleteIndex(name: String) {
+        objectStore.deleteIndex(name)
+    }
 }

--- a/core/src/jsTest/kotlin/Samples.kt
+++ b/core/src/jsTest/kotlin/Samples.kt
@@ -26,6 +26,8 @@ class Samples {
                 store.createIndex("name", KeyPath("name"), unique = false)
                 store.createIndex("age", KeyPath("age"), unique = false)
                 store.createIndex("email", KeyPath("email"), unique = true)
+                store.createIndex("unnecessary_index", KeyPath("unimporatant"), unique = true)
+                store.deleteIndex("unnecessary_index")
             }
         }
         onCleanup {


### PR DESCRIPTION
Needed deleteIndex method support for proper migration, but it wasn't in VersionChangeTransaction. Fixed it