### PR TITLE
Remove `MaxPermSize` Gradle option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Publication configuration
 # https://github.com/vanniktech/gradle-maven-publish-plugin#setting-properties


### PR DESCRIPTION
Option is not compatible with JDK 17:

```shell
FAILURE: Build failed with an exception.

* What went wrong:
Unable to start the daemon process.
This problem might be caused by incorrect configuration of the daemon.
For example, an unrecognized jvm option is used.For more details on the daemon, please refer to https://docs.gradle.org/8.3/userguide/gradle_daemon.html in the Gradle documentation.
Process command line: /Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home/bin/java -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xmx4g -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -cp ~/.gradle/wrapper/dists/gradle-8.3-bin/dxjbbhstwasg8cbags9q7cvli/gradle-8.3/lib/gradle-launcher-8.3.jar -javaagent:~/.gradle/wrapper/dists/gradle-8.3-bin/dxjbbhstwasg8cbags9q7cvli/gradle-8.3/lib/agents/gradle-instrumentation-agent-8.3.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.3
Please read the following process output to find out more:
-----------------------
Picked up JAVA_TOOL_OPTIONS: -Dapple.awt.UIElement=true
Unrecognized VM option 'MaxPermSize=2048m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```