### PR TITLE
Transaction Durability and Write Transaction Mutual Exclusion

### DIFF
--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -92,7 +92,7 @@ public class Database internal constructor(internal val database: IDBDatabase) {
         with(transaction) {
             // Force overlapping transactions to not call `action` until prior transactions complete.
             objectStore(store.first())
-                .openCursor(autoContinue = false)
+                .openKeyCursor(autoContinue = false)
                 .collect { it.close() }
         }
         val result = transaction.action()

--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -64,10 +64,12 @@ public class Database internal constructor(internal val database: IDBDatabase) {
      */
     public suspend fun <T> transaction(
         vararg store: String,
+        durability: Durability = Durability.Default,
         action: suspend Transaction.() -> T,
     ): T = withContext(Dispatchers.Unconfined) {
-        @Suppress("UNCHECKED_CAST") // What a silly cast. Apparently `vararg` creates `Array<out String>` instead of `Array<String>`
-        val transaction = Transaction(database.transaction(store as Array<String>, "readonly"))
+        val transaction = Transaction(
+            database.transaction(arrayOf(*store), "readonly", transactionOptions(durability)),
+        )
         val result = transaction.action()
         transaction.awaitCompletion()
         result
@@ -81,10 +83,18 @@ public class Database internal constructor(internal val database: IDBDatabase) {
      */
     public suspend fun <T> writeTransaction(
         vararg store: String,
+        durability: Durability = Durability.Default,
         action: suspend WriteTransaction.() -> T,
     ): T = withContext(Dispatchers.Unconfined) {
-        @Suppress("UNCHECKED_CAST") // What a silly cast. Apparently `vararg` creates `Array<out String>` instead of `Array<String>`
-        val transaction = WriteTransaction(database.transaction(store as Array<String>, "readwrite"))
+        val transaction = WriteTransaction(
+            database.transaction(arrayOf(*store), "readwrite", transactionOptions(durability)),
+        )
+        with(transaction) {
+            // Force overlapping transactions to not call `action` until prior transactions complete.
+            objectStore(store.first())
+                .openCursor(autoContinue = false)
+                .collect { it.close() }
+        }
         val result = transaction.action()
         transaction.awaitCompletion()
         result
@@ -93,4 +103,8 @@ public class Database internal constructor(internal val database: IDBDatabase) {
     public fun close() {
         database.close()
     }
+}
+
+private fun transactionOptions(durability: Durability): dynamic = jso {
+    this.durability = durability.jsValue
 }

--- a/core/src/jsMain/kotlin/Durability.kt
+++ b/core/src/jsMain/kotlin/Durability.kt
@@ -1,10 +1,19 @@
 package com.juul.indexeddb
 
+import com.juul.indexeddb.Durability.Default
+import com.juul.indexeddb.Durability.Relaxed
+import com.juul.indexeddb.Durability.Strict
+
 /** https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability */
-public enum class Durability(
-    internal val jsValue: String
-) {
-    Default("default"),
-    Strict("strict"),
-    Relaxed("relaxed");
+public enum class Durability {
+    Default,
+    Strict,
+    Relaxed,
 }
+
+internal val Durability.jsValue: String
+    get() = when (this) {
+        Default -> "default"
+        Strict -> "strict"
+        Relaxed -> "relaxed"
+    }

--- a/core/src/jsMain/kotlin/Durability.kt
+++ b/core/src/jsMain/kotlin/Durability.kt
@@ -1,0 +1,10 @@
+package com.juul.indexeddb
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability */
+public enum class Durability(
+    internal val jsValue: String
+) {
+    Default("default"),
+    Strict("strict"),
+    Relaxed("relaxed");
+}

--- a/external/src/jsMain/kotlin/IDBDatabase.kt
+++ b/external/src/jsMain/kotlin/IDBDatabase.kt
@@ -11,5 +11,5 @@ public external class IDBDatabase : EventTarget {
     public fun createObjectStore(name: String): IDBObjectStore
     public fun createObjectStore(name: String, options: dynamic): IDBObjectStore
     public fun deleteObjectStore(name: String)
-    public fun transaction(storeNames: Array<String>, mode: String): IDBTransaction
+    public fun transaction(storeNames: Array<String>, mode: String, options: dynamic): IDBTransaction
 }


### PR DESCRIPTION
1. Exposes durability to callers, so they can opt in to slower-but-safer DB writes.
2. Write transactions now force an event dispatch before calling the supplied action block, which brings their threading model closer to how I originally intended it. Previously, the mutual exclusion of write transactions didn't kick in until the first event suspended, which can be very confusing if you're side effecting inside the transaction (such as for logs)