### PR TITLE
Remove superfluous `setup-gradle` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
 
       - run: ./gradlew assemble
       - run: ./gradlew check


### PR DESCRIPTION
Per [v4.0.0](https://github.com/gradle/actions/releases/tag/v4.0.0) release notes:

> wrapper validation has been significantly improved, and is now enabled by default