### PR TITLE
Initial port for wasmJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ![badge][badge-js]
+![badge][badge-wasmJs]
 [![Slack](https://img.shields.io/badge/Slack-%23juul--libraries-ECB22E.svg?logo=data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgNTQgNTQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj48cGF0aCBkPSJNMTkuNzEyLjEzM2E1LjM4MSA1LjM4MSAwIDAgMC01LjM3NiA1LjM4NyA1LjM4MSA1LjM4MSAwIDAgMCA1LjM3NiA1LjM4Nmg1LjM3NlY1LjUyQTUuMzgxIDUuMzgxIDAgMCAwIDE5LjcxMi4xMzNtMCAxNC4zNjVINS4zNzZBNS4zODEgNS4zODEgMCAwIDAgMCAxOS44ODRhNS4zODEgNS4zODEgMCAwIDAgNS4zNzYgNS4zODdoMTQuMzM2YTUuMzgxIDUuMzgxIDAgMCAwIDUuMzc2LTUuMzg3IDUuMzgxIDUuMzgxIDAgMCAwLTUuMzc2LTUuMzg2IiBmaWxsPSIjMzZDNUYwIi8+PHBhdGggZD0iTTUzLjc2IDE5Ljg4NGE1LjM4MSA1LjM4MSAwIDAgMC01LjM3Ni01LjM4NiA1LjM4MSA1LjM4MSAwIDAgMC01LjM3NiA1LjM4NnY1LjM4N2g1LjM3NmE1LjM4MSA1LjM4MSAwIDAgMCA1LjM3Ni01LjM4N20tMTQuMzM2IDBWNS41MkE1LjM4MSA1LjM4MSAwIDAgMCAzNC4wNDguMTMzYTUuMzgxIDUuMzgxIDAgMCAwLTUuMzc2IDUuMzg3djE0LjM2NGE1LjM4MSA1LjM4MSAwIDAgMCA1LjM3NiA1LjM4NyA1LjM4MSA1LjM4MSAwIDAgMCA1LjM3Ni01LjM4NyIgZmlsbD0iIzJFQjY3RCIvPjxwYXRoIGQ9Ik0zNC4wNDggNTRhNS4zODEgNS4zODEgMCAwIDAgNS4zNzYtNS4zODcgNS4zODEgNS4zODEgMCAwIDAtNS4zNzYtNS4zODZoLTUuMzc2djUuMzg2QTUuMzgxIDUuMzgxIDAgMCAwIDM0LjA0OCA1NG0wLTE0LjM2NWgxNC4zMzZhNS4zODEgNS4zODEgMCAwIDAgNS4zNzYtNS4zODYgNS4zODEgNS4zODEgMCAwIDAtNS4zNzYtNS4zODdIMzQuMDQ4YTUuMzgxIDUuMzgxIDAgMCAwLTUuMzc2IDUuMzg3IDUuMzgxIDUuMzgxIDAgMCAwIDUuMzc2IDUuMzg2IiBmaWxsPSIjRUNCMjJFIi8+PHBhdGggZD0iTTAgMzQuMjQ5YTUuMzgxIDUuMzgxIDAgMCAwIDUuMzc2IDUuMzg2IDUuMzgxIDUuMzgxIDAgMCAwIDUuMzc2LTUuMzg2di01LjM4N0g1LjM3NkE1LjM4MSA1LjM4MSAwIDAgMCAwIDM0LjI1bTE0LjMzNi0uMDAxdjE0LjM2NEE1LjM4MSA1LjM4MSAwIDAgMCAxOS43MTIgNTRhNS4zODEgNS4zODEgMCAwIDAgNS4zNzYtNS4zODdWMzQuMjVhNS4zODEgNS4zODEgMCAwIDAtNS4zNzYtNS4zODcgNS4zODEgNS4zODEgMCAwIDAtNS4zNzYgNS4zODciIGZpbGw9IiNFMDFFNUEiLz48L2c+PC9zdmc+&labelColor=611f69)](https://kotlinlang.slack.com/messages/juul-libraries/)
 
 # Kotlin IndexedDB
 
-A wrapper around [IndexedDB] which allows for access from Kotlin/JS code using `suspend` blocks and linear, non-callback based control flow.
+A wrapper around [IndexedDB] which allows for access from Kotlin/JS or Kotlin/WasmJs code using `suspend` blocks and linear, non-callback based control flow.
 
 ## Usage
 
@@ -184,4 +185,5 @@ limitations under the License.
 [IndexedDB]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 [Using IndexedDB]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
 [//]: # (Images)
-[badge-js]: http://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat
+[badge-js]: https://img.shields.io/badge/platform-js-F8DB5D.svg?style=flat
+[badge-wasmJs]: https://img.shields.io/badge/platform-wasmJs-F8DB5D.svg?style=flat

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(buildDir.resolve("gh-pages"))
+    outputDirectory.set(layout.buildDirectory.dir("gh-pages"))
 }
 
 allprojects {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
@@ -13,30 +15,36 @@ kotlin {
         binaries.library()
     }
 
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        binaries.library()
+    }
+
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(libs.coroutines.core)
-            }
+        commonMain.dependencies {
+            api(libs.coroutines.core)
         }
 
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        commonTest.dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
         }
 
-        val jsMain by getting {
-            dependencies {
-                implementation(project(":external"))
-            }
+        jsMain.dependencies {
+            implementation(project(":external"))
         }
 
-        val jsTest by getting {
-            dependencies {
-                implementation(kotlin("test-js"))
-            }
+        jsTest.dependencies {
+            implementation(kotlin("test-js"))
+        }
+
+        wasmJsMain.dependencies {
+            implementation(project(":external"))
+        }
+
+        wasmJsTest.dependencies {
+            implementation(kotlin("test-wasm-js"))
         }
     }
 }

--- a/core/src/wasmJsMain/kotlin/Cursor.kt
+++ b/core/src/wasmJsMain/kotlin/Cursor.kt
@@ -1,0 +1,53 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+import com.juul.indexeddb.external.IDBCursorWithValue
+import kotlinx.coroutines.channels.SendChannel
+
+public open class Cursor internal constructor(
+    internal open val cursor: IDBCursor,
+    private val channel: SendChannel<*>,
+) {
+    public val key: JsAny
+        get() = cursor.key
+
+    public val primaryKey: JsAny
+        get() = cursor.primaryKey
+
+    public fun close() {
+        channel.close()
+    }
+
+    public fun `continue`() {
+        cursor.`continue`()
+    }
+
+    public fun advance(count: Int) {
+        cursor.advance(count)
+    }
+
+    public fun `continue`(key: Key) {
+        cursor.`continue`(key.toJs())
+    }
+
+    public fun continuePrimaryKey(key: Key, primaryKey: Key) {
+        cursor.continuePrimaryKey(key.toJs(), primaryKey.toJs())
+    }
+
+    public enum class Direction(
+        internal val constant: String,
+    ) {
+        Next("next"),
+        NextUnique("nextunique"),
+        Previous("prev"),
+        PreviousUnique("prevunique"),
+    }
+}
+
+public class CursorWithValue internal constructor(
+    override val cursor: IDBCursorWithValue,
+    channel: SendChannel<*>,
+) : Cursor(cursor, channel) {
+    public val value: JsAny?
+        get() = cursor.value
+}

--- a/core/src/wasmJsMain/kotlin/CursorStart.kt
+++ b/core/src/wasmJsMain/kotlin/CursorStart.kt
@@ -1,0 +1,33 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+
+public sealed class CursorStart {
+
+    internal abstract fun apply(cursor: IDBCursor)
+
+    public data class Advance(
+        val count: Int,
+    ) : CursorStart() {
+        override fun apply(cursor: IDBCursor) {
+            cursor.advance(count)
+        }
+    }
+
+    public data class Continue(
+        val key: Key,
+    ) : CursorStart() {
+        override fun apply(cursor: IDBCursor) {
+            cursor.`continue`(key.toJs())
+        }
+    }
+
+    public data class ContinuePrimaryKey(
+        val key: Key,
+        val primaryKey: Key,
+    ) : CursorStart() {
+        override fun apply(cursor: IDBCursor) {
+            cursor.continuePrimaryKey(key.toJs(), primaryKey.toJs())
+        }
+    }
+}

--- a/core/src/wasmJsMain/kotlin/Database.kt
+++ b/core/src/wasmJsMain/kotlin/Database.kt
@@ -1,0 +1,150 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBDatabase
+import com.juul.indexeddb.external.IDBFactory
+import com.juul.indexeddb.external.IDBTransactionDurability
+import com.juul.indexeddb.external.IDBTransactionOptions
+import com.juul.indexeddb.external.IDBVersionChangeEvent
+import com.juul.indexeddb.external.indexedDB
+import kotlinx.browser.window
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Inside the [initialize] block, you must not call any `suspend` functions except for:
+ * - those provided by this library and scoped on [Transaction] (and its subclasses)
+ * - flow operations on the flows returns by [Transaction.openCursor] and [Transaction.openKeyCursor]
+ * - `suspend` functions composed entirely of other legal functions
+ */
+public suspend fun openDatabase(
+    name: String,
+    version: Int,
+    initialize: suspend VersionChangeTransaction.(
+        database: Database,
+        oldVersion: Int,
+        newVersion: Int,
+    ) -> Unit,
+): Database = withContext(Dispatchers.Unconfined) {
+    val indexedDB: IDBFactory? = selfIndexedDB
+    val factory = checkNotNull(indexedDB) { "Your browser doesn't support IndexedDB." }
+    val request = factory.open(name, version)
+    val versionChangeEvent = request.onNextEvent("success", "upgradeneeded", "error", "blocked") { event ->
+        when (event.type) {
+            "upgradeneeded" -> event as IDBVersionChangeEvent
+            "error" -> throw ErrorEventException(event)
+            "blocked" -> throw OpenBlockedException(name, event)
+            else -> null
+        }
+    }
+    Database(request.result).also { database ->
+        if (versionChangeEvent != null) {
+            val transaction = VersionChangeTransaction(checkNotNull(request.transaction))
+            transaction.initialize(
+                database,
+                versionChangeEvent.oldVersion,
+                versionChangeEvent.newVersion,
+            )
+            transaction.awaitCompletion()
+        }
+    }
+}
+
+public suspend fun deleteDatabase(name: String) {
+    val factory = checkNotNull(window.indexedDB) { "Your browser doesn't support IndexedDB." }
+    val request = factory.deleteDatabase(name)
+    request.onNextEvent("success", "error", "blocked") { event ->
+        when (event.type) {
+            "error", "blocked" -> throw ErrorEventException(event)
+            else -> null
+        }
+    }
+}
+
+public class Database internal constructor(
+    database: IDBDatabase,
+) {
+    private var database: IDBDatabase? = database
+
+    init {
+        // listen for database structure changes (e.g., upgradeneeded while DB is open or deleteDatabase)
+        database.addEventListener("versionchange") { close() }
+        // listen for force close, e.g., browser profile on a USB drive that's ejected or db deleted through dev tools
+        database.addEventListener("close") { close() }
+    }
+
+    internal fun ensureDatabase(): IDBDatabase = checkNotNull(database) { "database is closed" }
+
+    /**
+     * Inside the [action] block, you must not call any `suspend` functions except for:
+     * - those provided by this library and scoped on [Transaction] (and its subclasses)
+     * - flow operations on the flows returns by [Transaction.openCursor] and [Transaction.openKeyCursor]
+     * - `suspend` functions composed entirely of other legal functions
+     */
+    public suspend fun <T> transaction(
+        vararg store: String,
+        durability: IDBTransactionDurability = IDBTransactionDurability.Default,
+        action: suspend Transaction.() -> T,
+    ): T = withContext(Dispatchers.Unconfined) {
+        check(store.isNotEmpty()) {
+            "At least one store needs to be passed to transaction"
+        }
+
+        val transaction = Transaction(
+            ensureDatabase().transaction(
+                storeNames = ReadonlyArray(
+                    *store.map { it.toJsString() }.toTypedArray(),
+                ),
+                mode = "readonly",
+                options = IDBTransactionOptions(durability),
+            ),
+        )
+        val result = transaction.action()
+        transaction.awaitCompletion()
+        result
+    }
+
+    /**
+     * Inside the [action] block, you must not call any `suspend` functions except for:
+     * - those provided by this library and scoped on [Transaction] (and its subclasses)
+     * - flow operations on the flows returns by [Transaction.openCursor] and [Transaction.openKeyCursor]
+     * - `suspend` functions composed entirely of other legal functions
+     */
+    public suspend fun <T> writeTransaction(
+        vararg store: String,
+        durability: IDBTransactionDurability = IDBTransactionDurability.Default,
+        action: suspend WriteTransaction.() -> T,
+    ): T = withContext(Dispatchers.Unconfined) {
+        check(store.isNotEmpty()) {
+            "At least one store needs to be passed to writeTransaction"
+        }
+
+        val transaction = WriteTransaction(
+            ensureDatabase()
+                .transaction(
+                    storeNames = ReadonlyArray(
+                        *store.map { it.toJsString() }.toTypedArray(),
+                    ),
+                    mode = "readwrite",
+                    options = IDBTransactionOptions(durability),
+                ),
+        )
+
+        with(transaction) {
+            // Force overlapping transactions to not call `action` until prior transactions complete.
+            objectStore(store.first())
+                .openKeyCursor(autoContinue = false)
+                .collect { it.close() }
+        }
+        val result = transaction.action()
+        transaction.awaitCompletion()
+        result
+    }
+
+    public fun close() {
+        database?.close()
+        database = null
+    }
+}
+
+@Suppress("RedundantNullableReturnType")
+private val selfIndexedDB: IDBFactory? = js("self.indexedDB || self.webkitIndexedDB")

--- a/core/src/wasmJsMain/kotlin/Exceptions.kt
+++ b/core/src/wasmJsMain/kotlin/Exceptions.kt
@@ -1,0 +1,25 @@
+package com.juul.indexeddb
+
+import org.w3c.dom.events.Event
+
+public abstract class EventException(
+    message: String?,
+    cause: Throwable?,
+    public val event: Event,
+) : Exception(message, cause)
+
+public class EventHandlerException(
+    cause: Throwable?,
+    event: Event,
+) : EventException("An inner exception was thrown: $cause", cause, event)
+
+public class ErrorEventException(
+    event: Event,
+) : EventException("An error event was received.", cause = null, event)
+public class OpenBlockedException(
+    public val name: String,
+    event: Event,
+) : EventException("Resource in use: $name.", cause = null, event)
+public class AbortTransactionException(
+    event: Event,
+) : EventException("Transaction aborted while waiting for completion.", cause = null, event)

--- a/core/src/wasmJsMain/kotlin/Index.kt
+++ b/core/src/wasmJsMain/kotlin/Index.kt
@@ -1,0 +1,25 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+import com.juul.indexeddb.external.IDBCursorWithValue
+import com.juul.indexeddb.external.IDBIndex
+import com.juul.indexeddb.external.ReadonlyArray
+
+public class Index internal constructor(
+    internal val index: IDBIndex,
+) : Queryable() {
+    override fun requestGet(key: Key): Request<*> =
+        Request(index.get(key.toJs()))
+
+    override fun requestGetAll(query: Key?): Request<ReadonlyArray<*>> =
+        Request(index.getAll(query?.toJs()))
+
+    override fun requestOpenCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursorWithValue?> =
+        Request(index.openCursor(query?.toJs(), direction.constant))
+
+    override fun requestOpenKeyCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursor?> =
+        Request(index.openKeyCursor(query?.toJs(), direction.constant))
+
+    override fun requestCount(query: Key?): Request<JsNumber> =
+        Request(index.count(query?.toJs()))
+}

--- a/core/src/wasmJsMain/kotlin/JsArray.kt
+++ b/core/src/wasmJsMain/kotlin/JsArray.kt
@@ -1,0 +1,24 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.ReadonlyArray
+
+internal fun Iterable<String?>.toJsArray(): JsArray<JsString?> =
+    kotlin.js.JsArray<JsString?>().apply {
+        forEachIndexed { index, s ->
+            set(index, s?.toJsString())
+        }
+    }
+
+internal fun <T : JsAny?> JsArray(vararg values: T): JsArray<T> =
+    kotlin.js.JsArray<T>().apply {
+        for (i in values.indices) {
+            set(i, values[i])
+        }
+    }
+
+internal fun <T : JsAny?> ReadonlyArray(vararg values: T): ReadonlyArray<T> =
+    kotlin.js.JsArray<T>().apply {
+        for (i in values.indices) {
+            set(i, values[i])
+        }
+    }

--- a/core/src/wasmJsMain/kotlin/Jso.kt
+++ b/core/src/wasmJsMain/kotlin/Jso.kt
@@ -1,0 +1,6 @@
+package com.juul.indexeddb
+// Copied from:
+// https://github.com/JetBrains/kotlin-wrappers/blob/91b2c1568ec6f779af5ec10d89b5e2cbdfe785ff/kotlin-extensions/src/main/kotlin/kotlinx/js/jso.kt
+
+internal fun <T : JsAny> jso(): T = js("({})")
+internal fun <T : JsAny> jso(block: T.() -> Unit): T = jso<T>().apply(block)

--- a/core/src/wasmJsMain/kotlin/Key.kt
+++ b/core/src/wasmJsMain/kotlin/Key.kt
@@ -1,0 +1,68 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBKey
+import com.juul.indexeddb.external.IDBKeyRange
+import org.khronos.webgl.Uint8Array
+
+public external class Date(
+    value: JsString,
+) : JsAny
+
+private fun JsArray<JsAny?>.validateKeyTypes() {
+    for (i in 0..<length) {
+        @Suppress("UNCHECKED_CAST")
+        when (val value = get(i)) {
+            null, is Uint8Array, is JsString, is Date, is JsNumber, is IDBKeyRange -> continue
+            is JsArray<*> -> (value as JsArray<JsAny?>).validateKeyTypes()
+            else -> error("Illegal key: expected string, date, float, binary blob, or array of those types, but got $value.")
+        }
+    }
+}
+
+public object AutoIncrement
+
+public class KeyPath private constructor(
+    private val paths: List<String?>,
+) {
+    init {
+        require(paths.isNotEmpty()) { "A key path must have at least one member." }
+    }
+
+    public constructor(path: String?, vararg morePaths: String?) : this(listOf(path, *morePaths))
+
+    internal fun toJs(): JsAny? = if (paths.size == 1) paths[0]?.toJsString() else paths.toJsArray()
+}
+
+public class Key(
+    value: JsAny?,
+    vararg moreValues: JsAny?,
+) {
+    private val values: JsArray<JsAny?> = JsArray(value, *moreValues)
+    init {
+        require(values.length >= 0) { "A key must have at least one member." }
+        values.validateKeyTypes()
+    }
+
+    internal fun toJs(): IDBKey = (if (values.length == 1) values[0]!! else values).unsafeCast()
+}
+
+public fun lowerBound(
+    x: JsAny?,
+    open: Boolean = false,
+): Key = Key(IDBKeyRange.lowerBound(x, open))
+
+public fun upperBound(
+    y: JsAny?,
+    open: Boolean = false,
+): Key = Key(IDBKeyRange.upperBound(y, open))
+
+public fun bound(
+    x: JsAny?,
+    y: JsAny?,
+    lowerOpen: Boolean = false,
+    upperOpen: Boolean = false,
+): Key = Key(IDBKeyRange.bound(x, y, lowerOpen, upperOpen))
+
+public fun only(
+    z: JsAny?,
+): Key = Key(IDBKeyRange.only(z))

--- a/core/src/wasmJsMain/kotlin/ObjectStore.kt
+++ b/core/src/wasmJsMain/kotlin/ObjectStore.kt
@@ -1,0 +1,25 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+import com.juul.indexeddb.external.IDBCursorWithValue
+import com.juul.indexeddb.external.IDBObjectStore
+import com.juul.indexeddb.external.ReadonlyArray
+
+public class ObjectStore internal constructor(
+    internal val objectStore: IDBObjectStore,
+) : Queryable() {
+    override fun requestGet(key: Key): Request<*> =
+        Request(objectStore.get(key.toJs()))
+
+    override fun requestGetAll(query: Key?): Request<ReadonlyArray<*>> =
+        Request(objectStore.getAll(query?.toJs()))
+
+    override fun requestOpenCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursorWithValue?> =
+        Request(objectStore.openCursor(query?.toJs(), direction.constant))
+
+    override fun requestOpenKeyCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursor?> =
+        Request(objectStore.openKeyCursor(query?.toJs(), direction.constant))
+
+    override fun requestCount(query: Key?): Request<JsNumber> =
+        Request(objectStore.count(query?.toJs()))
+}

--- a/core/src/wasmJsMain/kotlin/OnNextEvent.kt
+++ b/core/src/wasmJsMain/kotlin/OnNextEvent.kt
@@ -1,0 +1,27 @@
+package com.juul.indexeddb
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventTarget
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/** Subscribes to events matching [types], unsubscribing immediately before [action] is called. */
+internal suspend fun <T> EventTarget.onNextEvent(
+    vararg types: String,
+    action: (Event) -> T,
+): T = suspendCancellableCoroutine { continuation ->
+    lateinit var callback: (Event) -> Unit
+    callback = { event ->
+        types.forEach { type -> removeEventListener(type, callback) }
+        try {
+            continuation.resume(action.invoke(event))
+        } catch (t: Throwable) {
+            continuation.resumeWithException(EventHandlerException(t, event))
+        }
+    }
+    types.forEach { type -> addEventListener(type, callback) }
+    continuation.invokeOnCancellation {
+        types.forEach { type -> removeEventListener(type, callback) }
+    }
+}

--- a/core/src/wasmJsMain/kotlin/Queryable.kt
+++ b/core/src/wasmJsMain/kotlin/Queryable.kt
@@ -1,0 +1,13 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+import com.juul.indexeddb.external.IDBCursorWithValue
+import com.juul.indexeddb.external.ReadonlyArray
+
+public sealed class Queryable {
+    internal abstract fun requestGet(key: Key): Request<*>
+    internal abstract fun requestGetAll(query: Key?): Request<ReadonlyArray<*>>
+    internal abstract fun requestOpenCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursorWithValue?>
+    internal abstract fun requestOpenKeyCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursor?>
+    internal abstract fun requestCount(query: Key?): Request<JsNumber>
+}

--- a/core/src/wasmJsMain/kotlin/Request.kt
+++ b/core/src/wasmJsMain/kotlin/Request.kt
@@ -1,0 +1,7 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBRequest
+
+public class Request<T : JsAny?> internal constructor(
+    internal val request: IDBRequest<T>,
+)

--- a/core/src/wasmJsMain/kotlin/Transaction.kt
+++ b/core/src/wasmJsMain/kotlin/Transaction.kt
@@ -1,0 +1,340 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBCursor
+import com.juul.indexeddb.external.IDBObjectStoreOptions
+import com.juul.indexeddb.external.IDBRequest
+import com.juul.indexeddb.external.IDBTransaction
+import com.juul.indexeddb.external.ReadonlyArray
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import org.w3c.dom.events.Event
+
+public open class Transaction internal constructor(
+    internal val transaction: IDBTransaction,
+) {
+
+    internal suspend fun awaitCompletion() {
+        transaction.onNextEvent("complete", "abort", "error") { event ->
+            when (event.type) {
+                "abort" -> throw AbortTransactionException(event)
+                "error" -> throw ErrorEventException(event)
+                else -> Unit
+            }
+        }
+    }
+
+    public fun objectStore(name: String): ObjectStore =
+        ObjectStore(transaction.objectStore(name))
+
+    public suspend fun Queryable.get(key: Key): JsAny? {
+        val request = requestGet(key).request
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    public suspend fun Queryable.getAll(query: Key? = null): ReadonlyArray<*> {
+        val request = requestGetAll(query).request
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    @Deprecated(
+        "In the future, `autoContinue` will be a required parameter.",
+        ReplaceWith("openCursor(query, direction, cursorStart, autoContinue = true)"),
+    )
+    public suspend fun Queryable.openCursor(
+        query: Key? = null,
+        direction: Cursor.Direction = Cursor.Direction.Next,
+        cursorStart: CursorStart? = null,
+    ): Flow<CursorWithValue> = openCursor(
+        query,
+        direction,
+        cursorStart,
+        autoContinue = true,
+    )
+
+    /**
+     * When [autoContinue] is `true`, all values matching the query will emit automatically. It is important
+     * not to suspend in flow collection on _anything_ other than flow operators (such as `.toList`).
+     *
+     * Warning: when [autoContinue] is `false`, callers are responsible for data flow and must call `continue`, `advance`,
+     * or similar explicitly. The returned flow will terminate automatically after `continue` if no more elements
+     * remain. Otherwise, you must call `close` to terminate the flow. Failing to call `continue` or `close`
+     * will result in the flow stalling.
+     */
+    public suspend fun Queryable.openCursor(
+        query: Key? = null,
+        direction: Cursor.Direction = Cursor.Direction.Next,
+        cursorStart: CursorStart? = null,
+        autoContinue: Boolean,
+    ): Flow<CursorWithValue> = openCursorImpl(
+        query,
+        direction,
+        cursorStart,
+        open = this::requestOpenCursor,
+        wrap = ::CursorWithValue,
+        autoContinue,
+    )
+
+    @Deprecated(
+        "In the future, `autoContinue` will be a required parameter.",
+        ReplaceWith("openKeyCursor(query, direction, cursorStart, autoContinue = true)"),
+    )
+    public suspend fun Queryable.openKeyCursor(
+        query: Key? = null,
+        direction: Cursor.Direction = Cursor.Direction.Next,
+        cursorStart: CursorStart? = null,
+    ): Flow<Cursor> = openKeyCursor(
+        query,
+        direction,
+        cursorStart,
+        autoContinue = true,
+    )
+
+    /**
+     * When [autoContinue] is `true`, all values matching the query will emit automatically. It is important
+     * not to suspend in flow collection on _anything_ other than flow operators (such as `.toList`).
+     *
+     * Warning: when [autoContinue] is `false`, callers are responsible for data flow and must call `continue`, `advance`,
+     * or similar explicitly. The returned flow will terminate automatically after `continue` if no more elements
+     * remain. Otherwise, you must call `close` to terminate the flow. Failing to call `continue` or `close`
+     * will result in the flow stalling.
+     */
+    public suspend fun Queryable.openKeyCursor(
+        query: Key? = null,
+        direction: Cursor.Direction = Cursor.Direction.Next,
+        cursorStart: CursorStart? = null,
+        autoContinue: Boolean,
+    ): Flow<Cursor> = openCursorImpl(
+        query,
+        direction,
+        cursorStart,
+        open = this::requestOpenKeyCursor,
+        wrap = ::Cursor,
+        autoContinue,
+    )
+
+    private suspend fun <T : Cursor, U : IDBCursor> openCursorImpl(
+        query: Key?,
+        direction: Cursor.Direction,
+        cursorStart: CursorStart?,
+        open: (Key?, Cursor.Direction) -> Request<U?>,
+        wrap: (U, SendChannel<*>) -> T,
+        autoContinue: Boolean,
+    ): Flow<T> = callbackFlow {
+        var cursorStartAction = cursorStart
+        val request = open(query, direction).request
+        val onSuccess: (Event) -> Unit = { event ->
+            @Suppress("UNCHECKED_CAST")
+            val cursor = (event.target as IDBRequest<U?>).result
+            if (cursorStartAction != null && cursor != null) {
+                cursorStartAction?.apply(cursor)
+                cursorStartAction = null
+            } else if (cursor != null) {
+                val result = trySend(wrap(cursor, channel))
+                when {
+                    result.isSuccess -> if (autoContinue) cursor.`continue`()
+                    result.isFailure -> channel.close(IllegalStateException("Send failed. Did you suspend illegally?"))
+                    result.isClosed -> channel.close()
+                }
+            } else {
+                channel.close()
+            }
+        }
+        val onError: (Event) -> Unit = { event -> channel.close(ErrorEventException(event)) }
+        request.addEventListener("success", onSuccess)
+        request.addEventListener("error", onError)
+        awaitClose {
+            request.removeEventListener("success", onSuccess)
+            request.removeEventListener("error", onError)
+        }
+    }
+
+    public suspend fun Queryable.count(query: Key? = null): JsNumber {
+        val request = requestCount(query).request
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    public fun ObjectStore.index(name: String): Index =
+        Index(objectStore.index(name))
+}
+
+public open class WriteTransaction internal constructor(
+    transaction: IDBTransaction,
+) : Transaction(transaction) {
+
+    /**
+     * Adds a new item to the database using an in-line or auto-incrementing key. If an item with the same
+     * key already exists, this will fail.
+     *
+     * This API is delicate. If you're passing in Kotlin objects directly, you're probably doing it wrong.
+     *
+     * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
+     * doesn't mangle, prefix, or otherwise mess with your field names.
+     */
+    public suspend fun ObjectStore.add(item: JsAny?): JsAny {
+        val request = objectStore.add(item)
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    /**
+     * Adds a new item to the database using an explicit out-of-line key. If an item with the same key already
+     * exists, this will fail.
+     *
+     * This API is delicate. If you're passing in Kotlin objects directly, you're probably doing it wrong.
+     *
+     * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
+     * doesn't mangle, prefix, or otherwise mess with your field names.
+     */
+    public suspend fun ObjectStore.add(item: JsAny?, key: Key): JsAny {
+        val request = objectStore.add(item, key.toJs())
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    /**
+     * Adds an item to or updates an item in the database using an in-line or auto-incrementing key. If an item
+     * with the same key already exists, this will replace that item. Note that with auto-incrementing keys a new
+     * item will always be inserted.
+     *
+     * This API is delicate. If you're passing in Kotlin objects directly, you're probably doing it wrong.
+     *
+     * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
+     * doesn't mangle, prefix, or otherwise mess with your field names.
+     */
+    public suspend fun ObjectStore.put(item: JsAny?): JsAny {
+        val request = objectStore.put(item)
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    /**
+     * Adds an item to or updates an item in the database using an explicit out-of-line key. If an item with the
+     * same key already exists, this will replace that item.
+     *
+     * This API is delicate. If you're passing in Kotlin objects directly, you're probably doing it wrong.
+     *
+     * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
+     * doesn't mangle, prefix, or otherwise mess with your field names.
+     */
+    public suspend fun ObjectStore.put(item: JsAny?, key: Key): JsAny {
+        val request = objectStore.put(item, key.toJs())
+        return request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
+    public suspend fun ObjectStore.delete(key: Key) {
+        val request = objectStore.delete(key.toJs())
+        request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> Unit
+            }
+        }
+    }
+
+    public suspend fun ObjectStore.clear() {
+        val request = objectStore.clear()
+        request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> Unit
+            }
+        }
+    }
+
+    public suspend fun CursorWithValue.delete() {
+        val request = cursor.delete()
+        request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> Unit
+            }
+        }
+    }
+
+    public suspend fun CursorWithValue.update(value: JsAny?) {
+        val request = cursor.update(value)
+        request.onNextEvent("success", "error") { event ->
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> Unit
+            }
+        }
+    }
+}
+
+public class VersionChangeTransaction internal constructor(
+    transaction: IDBTransaction,
+) : WriteTransaction(transaction) {
+
+    /** Creates an object-store that uses explicit out-of-line keys. */
+    public fun Database.createObjectStore(name: String): ObjectStore =
+        ObjectStore(ensureDatabase().createObjectStore(name))
+
+    /** Creates an object-store that uses in-line keys. */
+    public fun Database.createObjectStore(name: String, keyPath: KeyPath): ObjectStore =
+        ObjectStore(
+            ensureDatabase()
+                .createObjectStore(
+                    name = name,
+                    options = IDBObjectStoreOptions(
+                        autoIncrement = false,
+                        keyPath = keyPath.toJs(),
+                    ),
+                ),
+        )
+
+    /** Creates an object-store that uses out-of-line keys with a key-generator. */
+    public fun Database.createObjectStore(name: String, autoIncrement: AutoIncrement): ObjectStore =
+        ObjectStore(
+            ensureDatabase()
+                .createObjectStore(
+                    name = name,
+                    options = IDBObjectStoreOptions(autoIncrement = true),
+                ),
+        )
+
+    public fun Database.deleteObjectStore(name: String) {
+        ensureDatabase().deleteObjectStore(name)
+    }
+
+    public fun ObjectStore.createIndex(name: String, keyPath: KeyPath, unique: Boolean): Index =
+        Index(objectStore.createIndex(name, keyPath.toJs(), jso { this.unique = unique }))
+
+    public fun ObjectStore.deleteIndex(name: String) {
+        objectStore.deleteIndex(name)
+    }
+}

--- a/core/src/wasmJsTest/kotlin/AutoIncrementKeyObjectStore.kt
+++ b/core/src/wasmJsTest/kotlin/AutoIncrementKeyObjectStore.kt
@@ -1,0 +1,34 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private external interface User : JsAny {
+    var username: JsString
+}
+
+class AutoIncrementKeyObjectStore {
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("auto-increment-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", AutoIncrement)
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("auto-increment-keys")
+        }
+
+        val id = database.writeTransaction("users") {
+            objectStore("users").add(jso<User> { username = "Username".toJsString() })
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key(id))
+                ?.unsafeCast<User>()
+        }
+        assertEquals("Username", user?.username?.toString())
+    }
+}

--- a/core/src/wasmJsTest/kotlin/Common.kt
+++ b/core/src/wasmJsTest/kotlin/Common.kt
@@ -1,0 +1,40 @@
+package com.juul.indexeddb
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import kotlin.js.Promise
+import kotlin.test.AfterTest
+
+/**
+ * Runs a coroutine in a promise, which the Mocha runner is smart enough to block on.
+ *
+ * The [action] runs inside a [TestScope], which gives access to [TestScope.onCleanup]. This
+ * allows for test-specific [AfterTest] like behavior with access to `suspend` functions.
+ */
+@Suppress("EXPERIMENTAL_API_USAGE")
+internal fun runTest(
+    action: suspend TestScope.() -> Unit,
+): Promise<JsAny?> = GlobalScope.promise {
+    val testScope = TestScope(this)
+    try {
+        action.invoke(testScope)
+    } finally {
+        testScope.cleanup()
+    }
+}
+
+internal class TestScope(
+    inner: CoroutineScope,
+) : CoroutineScope by inner {
+
+    private val callbacks = mutableListOf<suspend () -> Unit>()
+
+    fun onCleanup(action: suspend () -> Unit) {
+        callbacks += action
+    }
+
+    suspend fun cleanup() {
+        callbacks.asReversed().forEach { it.invoke() }
+    }
+}

--- a/core/src/wasmJsTest/kotlin/InLineKeyObjectStore.kt
+++ b/core/src/wasmJsTest/kotlin/InLineKeyObjectStore.kt
@@ -1,0 +1,41 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private external interface InLineKeyUser : JsAny {
+    var id: JsString
+    var username: JsString
+}
+
+class InLineKeyObjectStore {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("in-line-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", KeyPath("id"))
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("in-line-keys")
+        }
+
+        database.writeTransaction("users") {
+            objectStore("users").add(
+                jso<InLineKeyUser> {
+                    id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a".toJsString()
+                    username = "Username".toJsString()
+                },
+            )
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a".toJsString()))
+                ?.unsafeCast<InLineKeyUser>()
+        }
+        assertEquals("Username", user?.username?.toString())
+    }
+}

--- a/core/src/wasmJsTest/kotlin/KeyTests.kt
+++ b/core/src/wasmJsTest/kotlin/KeyTests.kt
@@ -1,0 +1,70 @@
+package com.juul.indexeddb
+
+import com.juul.indexeddb.external.IDBKeyRange
+import org.khronos.webgl.Uint8Array
+import kotlin.test.Test
+import kotlin.test.assertFails
+
+public class KeyTests {
+
+    @Test
+    public fun constructor_withObjectType_shouldFail() {
+        assertFails { Key(jso()) }
+    }
+
+    @Test
+    public fun constructor_withArrayOfObjectType_shouldFail() {
+        assertFails { Key(JsArray(jso())) }
+    }
+
+    @Test
+    public fun constructor_withLong_shouldFail() {
+        assertFails { Key(4L.toJsBigInt()) }
+    }
+
+    @Test
+    public fun constructor_withString_completes() {
+        Key("string".toJsString())
+    }
+
+    @Test
+    public fun constructor_withDate_completes() {
+        Key(Date("2021-11-11T12:00:00".toJsString()))
+    }
+
+    @Test
+    public fun constructor_withNiceNumbers_completes() {
+        Key(1.toJsNumber(), 3.0.toJsNumber())
+    }
+
+    @Test
+    public fun constructor_withByteArray_completes() {
+        Key(
+            Uint8Array(
+                JsArray(
+                    1.toJsNumber(),
+                    2.toJsNumber(),
+                    3.toJsNumber(),
+                    4.toJsNumber(),
+                    5.toJsNumber(),
+                    6.toJsNumber(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    public fun constructor_withArrayOfString_completes() {
+        Key(JsArray(JsArray("foo".toJsString()), "bar".toJsString()))
+    }
+
+    @Test
+    public fun constructor_withRange_completes() {
+        Key(IDBKeyRange.upperBound("foobar".toJsString(), false))
+    }
+
+    @Test
+    public fun constructor_withNull_completes() {
+        Key(null)
+    }
+}

--- a/core/src/wasmJsTest/kotlin/OutOfLineKeyObjectStore.kt
+++ b/core/src/wasmJsTest/kotlin/OutOfLineKeyObjectStore.kt
@@ -1,0 +1,39 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private external interface OutOfLineKeyUser : JsAny {
+    var username: JsString
+}
+
+class OutOfLineKeyObjectStore {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("out-of-line-keys", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users")
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("out-of-line-keys")
+        }
+
+        database.writeTransaction("users") {
+            objectStore("users")
+                .add(
+                    jso<OutOfLineKeyUser> { username = "Username".toJsString() },
+                    Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a".toJsString()),
+                )
+        }
+
+        val user = database.transaction("users") {
+            objectStore("users")
+                .get(Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a".toJsString()))
+                ?.unsafeCast<OutOfLineKeyUser>()
+        }
+        assertEquals("Username", user?.username?.toString())
+    }
+}

--- a/core/src/wasmJsTest/kotlin/Samples.kt
+++ b/core/src/wasmJsTest/kotlin/Samples.kt
@@ -1,0 +1,123 @@
+package com.juul.indexeddb
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// This file is not a good unit test. Instead, it serves as proof of the README's usage sample.
+
+external interface Customer : JsAny {
+    var ssn: JsString
+    var name: JsString
+    var age: JsNumber
+    var email: JsString
+}
+
+@Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+class Samples {
+
+    @Test
+    fun simpleReadWrite() = runTest {
+        val database = openDatabase("your-database-name", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                val store = database.createObjectStore("customers", KeyPath("ssn"))
+                store.createIndex("name", KeyPath("name"), unique = false)
+                store.createIndex("age", KeyPath("age"), unique = false)
+                store.createIndex("email", KeyPath("email"), unique = true)
+                store.createIndex("unnecessary_index", KeyPath("unimporatant"), unique = true)
+                store.deleteIndex("unnecessary_index")
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("your-database-name")
+        }
+
+        database.writeTransaction("customers") {
+            val store = objectStore("customers")
+            store.add(
+                jso<Customer> {
+                    ssn = "333-33-3333".toJsString()
+                    name = "Alice".toJsString()
+                    age = 33.toJsNumber()
+                    email = "alice@company.com".toJsString()
+                },
+            )
+            store.add(
+                jso<Customer> {
+                    ssn = "444-44-4444".toJsString()
+                    name = "Bill".toJsString()
+                    age = 35.toJsNumber()
+                    email = "bill@company.com".toJsString()
+                },
+            )
+            store.add(
+                jso<Customer> {
+                    ssn = "555-55-5555".toJsString()
+                    name = "Charlie".toJsString()
+                    age = 29.toJsNumber()
+                    email = "charlie@home.org".toJsString()
+                },
+            )
+            store.add(
+                jso<Customer> {
+                    ssn = "666-66-6666".toJsString()
+                    name = "Donna".toJsString()
+                    age = 31.toJsNumber()
+                    email = "donna@home.org".toJsString()
+                },
+            )
+        }
+
+        val bill = database.transaction("customers") {
+            objectStore("customers").get(Key("444-44-4444".toJsString())) as Customer
+        }
+        assertEquals("Bill", bill.name.toString())
+
+        val donna = database.transaction("customers") {
+            objectStore("customers").index("age").get(bound(30.toJsNumber(), 32.toJsNumber())) as Customer
+        }
+        assertEquals("Donna", donna.name.toString())
+
+        val charlie = database.transaction("customers") {
+            objectStore("customers")
+                .index("name")
+                .openCursor(autoContinue = true)
+                .map { it.value as Customer }
+                .first { it.age.toInt() < 32 }
+        }
+        assertEquals("Charlie", charlie.name.toString())
+
+        val count = database.transaction("customers") {
+            objectStore("customers").count()
+        }
+        assertEquals(4, count.toInt())
+
+        val countBelowThirtyTwo = database.transaction("customers") {
+            objectStore("customers").index("age").count(upperBound(32.toJsNumber()))
+        }
+        assertEquals(2, countBelowThirtyTwo.toInt())
+
+        val skipTwoYoungest = database.transaction("customers") {
+            objectStore("customers")
+                .index("age")
+                .openCursor(cursorStart = CursorStart.Advance(2), autoContinue = true)
+                .map { it.value as Customer }
+                .map { it.name }
+                .toList()
+        }
+        assertEquals(listOf("Alice", "Bill"), skipTwoYoungest.map { it.toString() })
+
+        val skipUntil33 = database.transaction("customers") {
+            objectStore("customers")
+                .index("age")
+                .openCursor(cursorStart = CursorStart.Continue(Key(33.toJsNumber())), autoContinue = true)
+                .map { it.value as Customer }
+                .map { it.name }
+                .toList()
+        }
+        assertEquals(listOf("Alice", "Bill"), skipUntil33.map { it.toString() })
+    }
+}

--- a/external/build.gradle.kts
+++ b/external/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
@@ -9,6 +11,12 @@ kotlin {
     explicitApi()
 
     js {
+        browser()
+        binaries.library()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
         browser()
         binaries.library()
     }

--- a/external/src/jsMain/kotlin/IDBCursor.kt
+++ b/external/src/jsMain/kotlin/IDBCursor.kt
@@ -5,11 +5,9 @@ public external interface IDBCursor {
     public val key: dynamic
     public val primaryKey: dynamic
 
-    public fun `continue`()
-
     public fun advance(count: Int)
 
-    public fun `continue`(key: dynamic)
+    public fun `continue`(key: dynamic = definedExternally)
 
     public fun continuePrimaryKey(key: dynamic, primaryKey: dynamic)
 }

--- a/external/src/wasmJsMain/kotlin/IDBCursor.kt
+++ b/external/src/wasmJsMain/kotlin/IDBCursor.kt
@@ -1,0 +1,21 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor */
+public external interface IDBCursor : JsAny {
+    public val key: IDBKey
+    public val primaryKey: IDBKey
+
+    public fun advance(count: Int)
+
+    public fun `continue`(key: IDBKey = definedExternally)
+
+    public fun continuePrimaryKey(key: IDBKey, primaryKey: IDBKey)
+}
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBCursorWithValue */
+public external interface IDBCursorWithValue : IDBCursor {
+    public val value: JsAny?
+
+    public fun delete(): IDBRequest<*>
+    public fun update(value: JsAny?): IDBRequest<IDBKey>
+}

--- a/external/src/wasmJsMain/kotlin/IDBDatabase.kt
+++ b/external/src/wasmJsMain/kotlin/IDBDatabase.kt
@@ -1,0 +1,20 @@
+package com.juul.indexeddb.external
+
+import org.w3c.dom.events.EventTarget
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase */
+public external class IDBDatabase : EventTarget {
+    public val name: String
+    public val version: Int
+    public val objectStoreNames: JsArray<JsString>
+    public fun close()
+    public fun createObjectStore(name: String): IDBObjectStore
+    public fun createObjectStore(name: String, options: IDBObjectStoreOptions?): IDBObjectStore
+    public fun deleteObjectStore(name: String)
+
+    public fun transaction(
+        storeNames: ReadonlyArray<JsString>,
+        mode: String = definedExternally,
+        options: IDBTransactionOptions = definedExternally,
+    ): IDBTransaction
+}

--- a/external/src/wasmJsMain/kotlin/IDBFactory.kt
+++ b/external/src/wasmJsMain/kotlin/IDBFactory.kt
@@ -1,0 +1,14 @@
+package com.juul.indexeddb.external
+
+import org.w3c.dom.Window
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory */
+public external interface IDBFactory : JsAny {
+    public fun open(name: String, version: Int = definedExternally): IDBOpenDBRequest
+    public fun deleteDatabase(name: String): IDBOpenDBRequest
+}
+
+public val Window.indexedDB: IDBFactory? get() = com.juul.indexeddb.external.indexedDB
+
+@Suppress("RedundantNullableReturnType")
+public val indexedDB: IDBFactory? = js("window.indexedDB")

--- a/external/src/wasmJsMain/kotlin/IDBIndex.kt
+++ b/external/src/wasmJsMain/kotlin/IDBIndex.kt
@@ -1,0 +1,7 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex */
+public external interface IDBIndex : IDBQueryable {
+    public val name: String
+    public val objectStore: IDBObjectStore
+}

--- a/external/src/wasmJsMain/kotlin/IDBIndexOptions.kt
+++ b/external/src/wasmJsMain/kotlin/IDBIndexOptions.kt
@@ -1,0 +1,6 @@
+package com.juul.indexeddb.external
+
+public external interface IDBIndexOptions : JsAny {
+    public var multiEntry: Boolean?
+    public var unique: Boolean?
+}

--- a/external/src/wasmJsMain/kotlin/IDBKey.kt
+++ b/external/src/wasmJsMain/kotlin/IDBKey.kt
@@ -1,0 +1,3 @@
+package com.juul.indexeddb.external
+
+public external interface IDBKey : JsAny

--- a/external/src/wasmJsMain/kotlin/IDBKeyRange.kt
+++ b/external/src/wasmJsMain/kotlin/IDBKeyRange.kt
@@ -1,0 +1,22 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBKeyRange */
+public external class IDBKeyRange : JsAny {
+
+    public fun includes(value: JsAny?): Boolean
+
+    public companion object {
+        public fun lowerBound(x: JsAny?, open: Boolean = definedExternally): IDBKeyRange
+
+        public fun upperBound(y: JsAny?, open: Boolean = definedExternally): IDBKeyRange
+
+        public fun bound(
+            x: JsAny?,
+            y: JsAny?,
+            lowerOpen: Boolean = definedExternally,
+            upperOpen: Boolean = definedExternally,
+        ): IDBKeyRange
+
+        public fun only(z: JsAny?): IDBKeyRange
+    }
+}

--- a/external/src/wasmJsMain/kotlin/IDBObjectStore.kt
+++ b/external/src/wasmJsMain/kotlin/IDBObjectStore.kt
@@ -1,0 +1,24 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore */
+public external interface IDBObjectStore : IDBQueryable {
+    public val name: String
+
+    public fun add(value: JsAny?, key: IDBKey = definedExternally): IDBRequest<IDBKey>
+
+    public fun put(item: JsAny?, key: IDBKey = definedExternally): IDBRequest<IDBKey>
+
+    public fun delete(key: IDBKey): IDBRequest<*>
+    public fun delete(key: IDBKeyRange): IDBRequest<*>
+
+    public fun clear(): IDBRequest<*>
+
+    public fun index(name: String): IDBIndex
+    public fun deleteIndex(name: String)
+
+    public fun createIndex(
+        name: String,
+        keyPath: JsAny?,
+        options: IDBIndexOptions = definedExternally,
+    ): IDBIndex
+}

--- a/external/src/wasmJsMain/kotlin/IDBObjectStoreOptions.kt
+++ b/external/src/wasmJsMain/kotlin/IDBObjectStoreOptions.kt
@@ -1,0 +1,17 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/createObjectStore#parameters */
+public external interface IDBObjectStoreOptions : JsAny {
+    public val autoIncrement: Boolean?
+    public val keyPath: JsAny
+}
+
+public fun IDBObjectStoreOptions(
+    autoIncrement: Boolean,
+): IDBObjectStoreOptions =
+    js("({ autoIncrement: autoIncrement })")
+
+public fun IDBObjectStoreOptions(
+    autoIncrement: Boolean,
+    keyPath: JsAny?,
+): IDBObjectStoreOptions = js("({ autoIncrement: autoIncrement, keyPath: keyPath })")

--- a/external/src/wasmJsMain/kotlin/IDBQueryable.kt
+++ b/external/src/wasmJsMain/kotlin/IDBQueryable.kt
@@ -1,0 +1,54 @@
+package com.juul.indexeddb.external
+
+/** Pseudo-interface for the shared query functionality between [IDBIndex] and [IDBObjectStore]. */
+public external interface IDBQueryable : JsAny {
+
+    public fun count(key: IDBKey? = definedExternally): IDBRequest<JsNumber>
+    public fun count(key: IDBKeyRange): IDBRequest<JsNumber>
+
+    public fun get(key: IDBKey): IDBRequest<*>
+    public fun get(key: IDBKeyRange): IDBRequest<*>
+
+    public fun getAll(
+        query: IDBKey? = definedExternally,
+        count: Int = definedExternally,
+    ): IDBRequest<ReadonlyArray<*>>
+
+    public fun getAll(
+        query: IDBKeyRange?,
+        count: Int = definedExternally,
+    ): IDBRequest<ReadonlyArray<*>>
+
+    public fun getAllKeys(
+        query: IDBKey? = definedExternally,
+        count: Int = definedExternally,
+    ): IDBRequest<ReadonlyArray<IDBKey>>
+
+    public fun getAllKeys(
+        query: IDBKeyRange?,
+        count: Int = definedExternally,
+    ): IDBRequest<ReadonlyArray<IDBKey>>
+
+    public fun getKey(query: IDBKey): IDBRequest<IDBKey?>
+    public fun getKey(query: IDBKeyRange): IDBRequest<IDBKey?>
+
+    public fun openCursor(
+        query: IDBKey? = definedExternally,
+        direction: String = definedExternally,
+    ): IDBRequest<IDBCursorWithValue?>
+
+    public fun openCursor(
+        query: IDBKeyRange?,
+        direction: String = definedExternally,
+    ): IDBRequest<IDBCursorWithValue?>
+
+    public fun openKeyCursor(
+        query: IDBKey? = definedExternally,
+        direction: String = definedExternally,
+    ): IDBRequest<IDBCursor?>
+
+    public fun openKeyCursor(
+        query: IDBKeyRange?,
+        direction: String = definedExternally,
+    ): IDBRequest<IDBCursor?>
+}

--- a/external/src/wasmJsMain/kotlin/IDBRequest.kt
+++ b/external/src/wasmJsMain/kotlin/IDBRequest.kt
@@ -1,0 +1,19 @@
+package com.juul.indexeddb.external
+
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventTarget
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBRequest */
+public open external class IDBRequest<T : JsAny?> : EventTarget {
+    public val error: JsAny?
+    public val transaction: IDBTransaction?
+    public val result: T
+    public var onerror: (Event) -> Unit
+    public var onsuccess: (Event) -> Unit
+}
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest */
+public external class IDBOpenDBRequest : IDBRequest<IDBDatabase> {
+    public var onblocked: (Event) -> Unit
+    public var onupgradeneeded: (IDBVersionChangeEvent) -> Unit
+}

--- a/external/src/wasmJsMain/kotlin/IDBTransaction.kt
+++ b/external/src/wasmJsMain/kotlin/IDBTransaction.kt
@@ -1,0 +1,17 @@
+package com.juul.indexeddb.external
+
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventTarget
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction */
+public external class IDBTransaction : EventTarget {
+    public val objectStoreNames: JsArray<JsString> // Actually a DOMStringList
+    public val db: IDBDatabase
+    public val error: JsAny?
+    public fun objectStore(name: String): IDBObjectStore
+    public fun abort()
+    public fun commit()
+    public var onabort: (Event) -> Unit
+    public var onerror: (Event) -> Unit
+    public var oncomplete: (Event) -> Unit
+}

--- a/external/src/wasmJsMain/kotlin/IDBTransactionOptions.kt
+++ b/external/src/wasmJsMain/kotlin/IDBTransactionOptions.kt
@@ -1,0 +1,21 @@
+package com.juul.indexeddb.external
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability */
+public external interface IDBTransactionOptions : JsAny {
+    public val durability: JsString
+}
+
+private fun IDBTransactionOptions(durability: String): IDBTransactionOptions =
+    js("({ durability: durability })")
+
+public fun IDBTransactionOptions(durability: IDBTransactionDurability): IDBTransactionOptions =
+    IDBTransactionOptions(durability.value)
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/durability */
+public enum class IDBTransactionDurability(
+    public val value: String,
+) {
+    Default("default"),
+    Strict("strict"),
+    Relaxed("relaxed"),
+}

--- a/external/src/wasmJsMain/kotlin/IDBVersionChangeEvent.kt
+++ b/external/src/wasmJsMain/kotlin/IDBVersionChangeEvent.kt
@@ -1,0 +1,9 @@
+package com.juul.indexeddb.external
+
+import org.w3c.dom.events.Event
+
+/** https://developer.mozilla.org/en-US/docs/Web/API/IDBVersionChangeEvent */
+public abstract external class IDBVersionChangeEvent : Event {
+    public val oldVersion: Int
+    public val newVersion: Int
+}

--- a/external/src/wasmJsMain/kotlin/ReadonlyArray.kt
+++ b/external/src/wasmJsMain/kotlin/ReadonlyArray.kt
@@ -1,0 +1,3 @@
+package com.juul.indexeddb.external
+
+public typealias ReadonlyArray<T> = JsArray<out T>


### PR DESCRIPTION
I'd like to supply a common interface, but at first glance that looks like it might be a lot more work.

It seems like there is partial support for null keys in js, but [the spec](https://www.w3.org/TR/IndexedDB/#key-construct) seems to suggest that it shouldn't be allowed. I mirrored the null key support in wasmJs for now.

Fixes #157 