### PR TITLE
Logging Support

### DIFF
--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -46,11 +46,11 @@ public suspend fun openDatabase(
                 "Upgrading database `$name` from version `${versionChangeEvent.oldVersion}` to `${versionChangeEvent.newVersion}`"
             }
             val id = database.transactionId++
-            logger.log(Type.Transaction) { "Opened versionchange transaction $id" }
+            logger.log(Type.Transaction) { "Opened versionchange transaction $id on database `$name`" }
             val transaction = VersionChangeTransaction(checkNotNull(request.transaction), logger, id)
             transaction.initialize(database, versionChangeEvent.oldVersion, versionChangeEvent.newVersion)
             transaction.awaitCompletion { event ->
-                logger.log(Type.Transaction, event) { "Closed versionchange transaction $id" }
+                logger.log(Type.Transaction, event) { "Closed versionchange transaction $id on database `$name`" }
             }
         }
         logger.log(Type.Database) { "Opened database `$name`" }
@@ -115,10 +115,12 @@ public class Database internal constructor(
             id,
         )
 
-        logger.log(Type.Transaction) { "Opened readonly transaction $id using stores ${store.joinToString { "`$it`" }}" }
+        logger.log(Type.Transaction) {
+            "Opened readonly transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
+        }
         val result = transaction.action()
         transaction.awaitCompletion { event ->
-            logger.log(Type.Transaction, event) { "Closed readonly transaction $id" }
+            logger.log(Type.Transaction, event) { "Closed readonly transaction $id on database `$name`" }
         }
         result
     }
@@ -145,10 +147,12 @@ public class Database internal constructor(
             objectStore(store.first()).awaitTransaction()
         }
 
-        logger.log(Type.Transaction) { "Opened readwrite transaction $id" }
+        logger.log(Type.Transaction) {
+            "Opened readwrite transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
+        }
         val result = transaction.action()
         transaction.awaitCompletion { event ->
-            logger.log(Type.Transaction, event) { "Closed readwrite transaction $id" }
+            logger.log(Type.Transaction, event) { "Closed readwrite transaction $id on database `$name`" }
         }
         result
     }

--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -46,7 +46,7 @@ public suspend fun openDatabase(
                 "Upgrading database `$name` from version `${versionChangeEvent.oldVersion}` to `${versionChangeEvent.newVersion}`"
             }
             val id = database.transactionId++
-            logger.log(Type.Transaction) { "Opened versionchange transaction $id on database `$name`" }
+            logger.log(Type.Transaction) { "Opening versionchange transaction $id on database `$name`" }
             val transaction = VersionChangeTransaction(checkNotNull(request.transaction), logger, id)
             transaction.initialize(database, versionChangeEvent.oldVersion, versionChangeEvent.newVersion)
             transaction.awaitCompletion { event ->
@@ -109,15 +109,15 @@ public class Database internal constructor(
         action: suspend Transaction.() -> T,
     ): T = withContext(Dispatchers.Unconfined) {
         val id = transactionId++
+        logger.log(Type.Transaction) {
+            "Opened readonly transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
+        }
+
         val transaction = Transaction(
             ensureDatabase().transaction(arrayOf(*store), "readonly", transactionOptions(durability)),
             logger,
             id,
         )
-
-        logger.log(Type.Transaction) {
-            "Opened readonly transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
-        }
         val result = transaction.action()
         transaction.awaitCompletion { event ->
             logger.log(Type.Transaction, event) { "Closed readonly transaction $id on database `$name`" }
@@ -137,6 +137,10 @@ public class Database internal constructor(
         action: suspend WriteTransaction.() -> T,
     ): T = withContext(Dispatchers.Unconfined) {
         val id = transactionId++
+        logger.log(Type.Transaction) {
+            "Opening readwrite transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
+        }
+
         val transaction = WriteTransaction(
             ensureDatabase().transaction(arrayOf(*store), "readwrite", transactionOptions(durability)),
             logger,
@@ -145,10 +149,6 @@ public class Database internal constructor(
         with(transaction) {
             // Force overlapping transactions to not call `action` until prior transactions complete.
             objectStore(store.first()).awaitTransaction()
-        }
-
-        logger.log(Type.Transaction) {
-            "Opened readwrite transaction $id using stores ${store.joinToString { "`$it`" }} on database `$name`"
         }
         val result = transaction.action()
         transaction.awaitCompletion { event ->

--- a/core/src/jsMain/kotlin/Index.kt
+++ b/core/src/jsMain/kotlin/Index.kt
@@ -7,6 +7,13 @@ import com.juul.indexeddb.external.IDBIndex
 public class Index internal constructor(
     internal val index: IDBIndex,
 ) : Queryable() {
+
+    override val type: String
+        get() = "index"
+
+    override val name: String
+        get() = index.name
+
     override fun requestGet(key: Key): Request<dynamic> =
         Request(index.get(key.toJs()))
 

--- a/core/src/jsMain/kotlin/ObjectStore.kt
+++ b/core/src/jsMain/kotlin/ObjectStore.kt
@@ -7,6 +7,13 @@ import com.juul.indexeddb.external.IDBObjectStore
 public class ObjectStore internal constructor(
     internal val objectStore: IDBObjectStore,
 ) : Queryable() {
+
+    override val type: String
+        get() = "object store"
+
+    override val name: String
+        get() = objectStore.name
+
     override fun requestGet(key: Key): Request<dynamic> =
         Request(objectStore.get(key.toJs()))
 

--- a/core/src/jsMain/kotlin/Queryable.kt
+++ b/core/src/jsMain/kotlin/Queryable.kt
@@ -4,6 +4,8 @@ import com.juul.indexeddb.external.IDBCursor
 import com.juul.indexeddb.external.IDBCursorWithValue
 
 public sealed class Queryable {
+    internal abstract val type: String
+    internal abstract val name: String
     internal abstract fun requestGet(key: Key): Request<dynamic>
     internal abstract fun requestGetAll(query: Key?): Request<Array<dynamic>>
     internal abstract fun requestOpenCursor(query: Key?, direction: Cursor.Direction): Request<IDBCursorWithValue?>

--- a/core/src/jsMain/kotlin/Transaction.kt
+++ b/core/src/jsMain/kotlin/Transaction.kt
@@ -3,6 +3,8 @@ package com.juul.indexeddb
 import com.juul.indexeddb.external.IDBCursor
 import com.juul.indexeddb.external.IDBRequest
 import com.juul.indexeddb.external.IDBTransaction
+import com.juul.indexeddb.logs.Logger
+import com.juul.indexeddb.logs.Type
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -11,10 +13,14 @@ import org.w3c.dom.events.Event
 
 public open class Transaction internal constructor(
     internal val transaction: IDBTransaction,
+    internal val logger: Logger,
+    internal val transactionId: Long,
 ) {
+    internal var operationId: Int = 0
 
-    internal suspend fun awaitCompletion() {
+    internal suspend fun awaitCompletion(onComplete: ((Event) -> Unit)? = null) {
         transaction.onNextEvent("complete", "abort", "error") { event ->
+            onComplete?.invoke(event)
             when (event.type) {
                 "abort" -> throw AbortTransactionException(event)
                 "error" -> throw ErrorEventException(event)
@@ -23,28 +29,32 @@ public open class Transaction internal constructor(
         }
     }
 
+    internal suspend inline fun <T> Queryable.request(
+        functionName: String,
+        crossinline makeRequest: () -> IDBRequest<T>,
+    ): T {
+        val id = operationId++
+        logger.log(Type.Query) { "$functionName request on $type `$name` (transaction $transactionId, request $id)" }
+        val request = makeRequest()
+        return request.onNextEvent("success", "error") { event ->
+            logger.log(Type.Query, event) {
+                "$functionName response on $type `$name` (transaction $transactionId, request $id)"
+            }
+            when (event.type) {
+                "error" -> throw ErrorEventException(event)
+                else -> request.result
+            }
+        }
+    }
+
     public fun objectStore(name: String): ObjectStore =
         ObjectStore(transaction.objectStore(name))
 
-    public suspend fun Queryable.get(key: Key): dynamic {
-        val request = requestGet(key).request
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun Queryable.get(key: Key): dynamic =
+        request("get") { requestGet(key).request }
 
-    public suspend fun Queryable.getAll(query: Key? = null): Array<dynamic> {
-        val request = requestGetAll(query).request
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun Queryable.getAll(query: Key? = null): Array<dynamic> =
+        request("getAll") { requestGetAll(query).request }
 
     @Deprecated(
         "In the future, `autoContinue` will be a required parameter.",
@@ -158,15 +168,8 @@ public open class Transaction internal constructor(
         }
     }
 
-    public suspend fun Queryable.count(query: Key? = null): Int {
-        val request = requestCount(query).request
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun Queryable.count(query: Key? = null): Int =
+        request("count") { requestCount(query).request }
 
     public fun ObjectStore.index(name: String): Index =
         Index(objectStore.index(name))
@@ -174,7 +177,9 @@ public open class Transaction internal constructor(
 
 public open class WriteTransaction internal constructor(
     transaction: IDBTransaction,
-) : Transaction(transaction) {
+    logger: Logger,
+    transactionId: Long,
+) : Transaction(transaction, logger, transactionId) {
 
     /**
      * Adds a new item to the database using an in-line or auto-incrementing key. If an item with the same
@@ -185,15 +190,8 @@ public open class WriteTransaction internal constructor(
      * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
      * doesn't mangle, prefix, or otherwise mess with your field names.
      */
-    public suspend fun ObjectStore.add(item: dynamic): dynamic {
-        val request = objectStore.add(item)
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun ObjectStore.add(item: dynamic): dynamic =
+        request("add") { objectStore.add(item) }
 
     /**
      * Adds a new item to the database using an explicit out-of-line key. If an item with the same key already
@@ -204,15 +202,8 @@ public open class WriteTransaction internal constructor(
      * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
      * doesn't mangle, prefix, or otherwise mess with your field names.
      */
-    public suspend fun ObjectStore.add(item: dynamic, key: Key): dynamic {
-        val request = objectStore.add(item, key.toJs())
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun ObjectStore.add(item: dynamic, key: Key): dynamic =
+        request("add") { objectStore.add(item, key.toJs()) }
 
     /**
      * Adds an item to or updates an item in the database using an in-line or auto-incrementing key. If an item
@@ -224,15 +215,8 @@ public open class WriteTransaction internal constructor(
      * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
      * doesn't mangle, prefix, or otherwise mess with your field names.
      */
-    public suspend fun ObjectStore.put(item: dynamic): dynamic {
-        val request = objectStore.put(item)
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun ObjectStore.put(item: dynamic): dynamic =
+        request("put") { objectStore.put(item) }
 
     /**
      * Adds an item to or updates an item in the database using an explicit out-of-line key. If an item with the
@@ -243,34 +227,15 @@ public open class WriteTransaction internal constructor(
      * Generally, you'll want to create an explicit `external interface` and pass that in, to guarantee that Kotlin
      * doesn't mangle, prefix, or otherwise mess with your field names.
      */
-    public suspend fun ObjectStore.put(item: dynamic, key: Key): dynamic {
-        val request = objectStore.put(item, key.toJs())
-        return request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> request.result
-            }
-        }
-    }
+    public suspend fun ObjectStore.put(item: dynamic, key: Key): dynamic =
+        request("put") { objectStore.put(item, key.toJs()) }
 
     public suspend fun ObjectStore.delete(key: Key) {
-        val request = objectStore.delete(key.toJs())
-        request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> Unit
-            }
-        }
+        request("delete") { objectStore.delete(key.toJs()) }
     }
 
     public suspend fun ObjectStore.clear() {
-        val request = objectStore.clear()
-        request.onNextEvent("success", "error") { event ->
-            when (event.type) {
-                "error" -> throw ErrorEventException(event)
-                else -> Unit
-            }
-        }
+        request("clear") { objectStore.clear() }
     }
 
     public suspend fun CursorWithValue.delete() {
@@ -296,28 +261,40 @@ public open class WriteTransaction internal constructor(
 
 public class VersionChangeTransaction internal constructor(
     transaction: IDBTransaction,
-) : WriteTransaction(transaction) {
+    logger: Logger,
+    transactionId: Long,
+) : WriteTransaction(transaction, logger, transactionId) {
 
     /** Creates an object-store that uses explicit out-of-line keys. */
-    public fun Database.createObjectStore(name: String): ObjectStore =
-        ObjectStore(ensureDatabase().createObjectStore(name))
+    public fun Database.createObjectStore(name: String): ObjectStore {
+        logger.log(Type.Database) { "Creating object store: $name" }
+        return ObjectStore(ensureDatabase().createObjectStore(name))
+    }
 
     /** Creates an object-store that uses in-line keys. */
-    public fun Database.createObjectStore(name: String, keyPath: KeyPath): ObjectStore =
-        ObjectStore(ensureDatabase().createObjectStore(name, keyPath.toWrappedJs()))
+    public fun Database.createObjectStore(name: String, keyPath: KeyPath): ObjectStore {
+        logger.log(Type.Database) { "Creating object store: $name" }
+        return ObjectStore(ensureDatabase().createObjectStore(name, keyPath.toWrappedJs()))
+    }
 
     /** Creates an object-store that uses out-of-line keys with a key-generator. */
-    public fun Database.createObjectStore(name: String, autoIncrement: AutoIncrement): ObjectStore =
-        ObjectStore(ensureDatabase().createObjectStore(name, autoIncrement.toJs()))
+    public fun Database.createObjectStore(name: String, autoIncrement: AutoIncrement): ObjectStore {
+        logger.log(Type.Database) { "Creating object store: $name" }
+        return ObjectStore(ensureDatabase().createObjectStore(name, autoIncrement.toJs()))
+    }
 
     public fun Database.deleteObjectStore(name: String) {
+        logger.log(Type.Database) { "Deleting object store: $name" }
         ensureDatabase().deleteObjectStore(name)
     }
 
-    public fun ObjectStore.createIndex(name: String, keyPath: KeyPath, unique: Boolean): Index =
-        Index(objectStore.createIndex(name, keyPath.toUnwrappedJs(), jso { this.unique = unique }))
+    public fun ObjectStore.createIndex(name: String, keyPath: KeyPath, unique: Boolean): Index {
+        logger.log(Type.Database) { "Creating index: $name" }
+        return Index(objectStore.createIndex(name, keyPath.toUnwrappedJs(), jso { this.unique = unique }))
+    }
 
     public fun ObjectStore.deleteIndex(name: String) {
+        logger.log(Type.Database) { "Deleting index: $name" }
         objectStore.deleteIndex(name)
     }
 }

--- a/core/src/jsMain/kotlin/logs/EventAsMessageLogger.kt
+++ b/core/src/jsMain/kotlin/logs/EventAsMessageLogger.kt
@@ -27,11 +27,11 @@ private class EventAsMessageLogger(
     }
 
     private fun propertyStrings(event: Event): List<String> = buildList {
-        add("type: ${event.type}")
-        add("target: ${event.target}")
+        // event.target explicitly excluded since it just prints stuff like [object IDBTransaction], not actually useful
+        add("event.type: ${event.type}")
         if (event is IDBVersionChangeEvent) {
-            add("oldVersion: ${event.oldVersion}")
-            add("newVersion: ${event.newVersion}")
+            add("event.oldVersion: ${event.oldVersion}")
+            add("event.newVersion: ${event.newVersion}")
         }
     }
 }

--- a/core/src/jsMain/kotlin/logs/EventAsMessageLogger.kt
+++ b/core/src/jsMain/kotlin/logs/EventAsMessageLogger.kt
@@ -1,0 +1,37 @@
+package com.juul.indexeddb.logs
+
+import com.juul.indexeddb.external.IDBVersionChangeEvent
+import org.w3c.dom.events.Event
+
+public fun Logger.embedEventsInMessages(
+    separator: String = "\n    ",
+): Logger = EventAsMessageLogger(separator, this)
+
+private class EventAsMessageLogger(
+    private val separator: String,
+    private val delegate: Logger,
+) : Logger {
+
+    override fun log(type: Type, event: Event?, message: () -> String) {
+        delegate.log(type, null) {
+            buildString {
+                append(message())
+                if (event != null) {
+                    for (line in propertyStrings(event)) {
+                        append(separator)
+                        append(line)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun propertyStrings(event: Event): List<String> = buildList {
+        add("type: ${event.type}")
+        add("target: ${event.target}")
+        if (event is IDBVersionChangeEvent) {
+            add("oldVersion: ${event.oldVersion}")
+            add("newVersion: ${event.newVersion}")
+        }
+    }
+}

--- a/core/src/jsMain/kotlin/logs/FilteringLogger.kt
+++ b/core/src/jsMain/kotlin/logs/FilteringLogger.kt
@@ -1,0 +1,21 @@
+package com.juul.indexeddb.logs
+
+import org.w3c.dom.events.Event
+
+public fun Logger.filterTypes(vararg whitelist: Type): Logger =
+    filterTypes(whitelist.toSet())
+
+public fun Logger.filterTypes(whitelist: Set<Type>): Logger =
+    FilteringLogger(whitelist, this)
+
+private class FilteringLogger(
+    val whitelist: Set<Type>,
+    val delegate: Logger,
+) : Logger {
+
+    override fun log(type: Type, event: Event?, message: () -> String) {
+        if (type in whitelist) {
+            delegate.log(type, event, message)
+        }
+    }
+}

--- a/core/src/jsMain/kotlin/logs/Logger.kt
+++ b/core/src/jsMain/kotlin/logs/Logger.kt
@@ -1,0 +1,7 @@
+package com.juul.indexeddb.logs
+
+import org.w3c.dom.events.Event
+
+public interface Logger {
+    public fun log(type: Type, event: Event? = null, message: () -> String)
+}

--- a/core/src/jsMain/kotlin/logs/NoOpLogger.kt
+++ b/core/src/jsMain/kotlin/logs/NoOpLogger.kt
@@ -1,0 +1,8 @@
+package com.juul.indexeddb.logs
+
+import org.w3c.dom.events.Event
+
+public object NoOpLogger : Logger {
+
+    override fun log(type: Type, event: Event?, message: () -> String) {}
+}

--- a/core/src/jsMain/kotlin/logs/PrintLogger.kt
+++ b/core/src/jsMain/kotlin/logs/PrintLogger.kt
@@ -1,0 +1,14 @@
+package com.juul.indexeddb.logs
+
+import org.w3c.dom.events.Event
+
+public object PrintLogger : Logger {
+
+    override fun log(type: Type, event: Event?, message: () -> String) {
+        val msg = message()
+        when (event) {
+            null -> println("$type: $msg")
+            else -> println("$type (event=$event): $msg")
+        }
+    }
+}

--- a/core/src/jsMain/kotlin/logs/PrintLogger.kt
+++ b/core/src/jsMain/kotlin/logs/PrintLogger.kt
@@ -8,7 +8,7 @@ public object PrintLogger : Logger {
         val msg = message()
         when (event) {
             null -> println("$type: $msg")
-            else -> println("$type (event=$event): $msg")
+            else -> println("$type (event=${event.type}): $msg")
         }
     }
 }

--- a/core/src/jsMain/kotlin/logs/Type.kt
+++ b/core/src/jsMain/kotlin/logs/Type.kt
@@ -4,5 +4,5 @@ public enum class Type {
     Database,
     Transaction,
     Query,
-    // TODO: Cursor events would be nice, but they're slightly more complicated
+    Cursor,
 }

--- a/core/src/jsMain/kotlin/logs/Type.kt
+++ b/core/src/jsMain/kotlin/logs/Type.kt
@@ -1,0 +1,15 @@
+package com.juul.indexeddb.logs
+
+public enum class Type {
+    CursorClose,
+    CursorOpen,
+    CursorValue,
+    DatabaseClose,
+    DatabaseDelete,
+    DatabaseOpen,
+    DatabaseUpgrade,
+    QueryGet,
+    QuerySet,
+    TransactionClose,
+    TransactionOpen,
+}

--- a/core/src/jsMain/kotlin/logs/Type.kt
+++ b/core/src/jsMain/kotlin/logs/Type.kt
@@ -1,15 +1,8 @@
 package com.juul.indexeddb.logs
 
 public enum class Type {
-    CursorClose,
-    CursorOpen,
-    CursorValue,
-    DatabaseClose,
-    DatabaseDelete,
-    DatabaseOpen,
-    DatabaseUpgrade,
-    QueryGet,
-    QuerySet,
-    TransactionClose,
-    TransactionOpen,
+    Database,
+    Transaction,
+    Query,
+    // TODO: Cursor events would be nice, but they're slightly more complicated
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.0.21"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-khronicle-core = { module = "com.juul.khronicle:khronicle-core", version = "0.3.0" }
+khronicle-core = { module = "com.juul.khronicle:khronicle-core", version = "0.5.0" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "2.0.20"
 
 [libraries]
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+khronicle-core = { module = "com.juul.khronicle:khronicle-core", version = "0.3.0" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }

--- a/logging-khronicle/build.gradle.kts
+++ b/logging-khronicle/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jmailen.kotlinter")
+    id("org.jetbrains.dokka")
+    id("com.vanniktech.maven.publish")
+}
+
+kotlin {
+    explicitApi()
+
+    js {
+        browser()
+        binaries.library()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":core"))
+                api(libs.khronicle.core)
+            }
+        }
+    }
+}

--- a/logging-khronicle/src/jsMain/kotlin/Event.kt
+++ b/logging-khronicle/src/jsMain/kotlin/Event.kt
@@ -1,0 +1,6 @@
+package com.juul.indexeddb.logs
+
+import com.juul.khronicle.Key
+import org.w3c.dom.events.Event
+
+public object Event : Key<Event>

--- a/logging-khronicle/src/jsMain/kotlin/KhronicleLogger.kt
+++ b/logging-khronicle/src/jsMain/kotlin/KhronicleLogger.kt
@@ -1,0 +1,25 @@
+package com.juul.indexeddb.logs
+
+import com.juul.khronicle.Log
+import com.juul.khronicle.LogLevel
+import org.w3c.dom.events.Event as JsEvent
+
+public object KhronicleLogger : Logger {
+
+    override fun log(type: Type, event: JsEvent?, message: () -> String) {
+        val level = when (event?.type) {
+            "error", "blocked" -> LogLevel.Error
+            else -> when (type) {
+                Type.Database -> LogLevel.Info
+                Type.Transaction -> LogLevel.Debug
+                else -> LogLevel.Verbose
+            }
+        }
+        Log.dynamic(level = level, tag = "IndexedDB/$type") { metadata ->
+            if (event != null) {
+                metadata[Event] = event
+            }
+            message()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,4 +11,5 @@ pluginManagement {
 include(
     "core",
     "external",
+    "logging-khronicle",
 )


### PR DESCRIPTION
~Draft until after #170 merges, since this is going to be chock full of merge conflicts.~ With #170 temporarily on hold, gonna try getting this in. Sorry for the merge conflicts

Adds support for logging. Logs are leaning on the side of over-verbose (most calls log twice, once before performing the operation and again with the result). The default logger, `NoOpLogger`, never invokes the message lambda (and should therefore avoid most of runtime cost for running the logger).

<details>

<summary>Example output</summary>

The example output is from running the test in `Sample` using `PrintLogger`.

```
Database: Opening database `your-database-name` at version `1`
Database (event=upgradeneeded): Upgrading database `your-database-name` from version `0` to `1`
Transaction: Opened versionchange transaction 0
Database: Creating object store: customers
Database: Creating index: name
Database: Creating index: age
Database: Creating index: email
Database: Creating index: unnecessary_index
Database: Deleting index: unnecessary_index
Transaction (event=complete): Closed versionchange transaction 0
Database: Opened database `your-database-name`
Transaction: Opened readwrite transaction 1
Query: add request on object store `customers` (transaction 1, operation 0)
Query (event=success): add response on object store `customers` (transaction 1, operation 0)
Query: add request on object store `customers` (transaction 1, operation 1)
Query (event=success): add response on object store `customers` (transaction 1, operation 1)
Query: add request on object store `customers` (transaction 1, operation 2)
Query (event=success): add response on object store `customers` (transaction 1, operation 2)
Query: add request on object store `customers` (transaction 1, operation 3)
Query (event=success): add response on object store `customers` (transaction 1, operation 3)
Transaction (event=complete): Closed readwrite transaction 1
Transaction: Opened readonly transaction 2 using stores `customers`
Query: get request on object store `customers` (transaction 2, operation 0)
Query (event=success): get response on object store `customers` (transaction 2, operation 0)
Transaction (event=complete): Closed readonly transaction 2
Transaction: Opened readonly transaction 3 using stores `customers`
Query: get request on index `age` (transaction 3, operation 0)
Query (event=success): get response on index `age` (transaction 3, operation 0)
Transaction (event=complete): Closed readonly transaction 3
Transaction: Opened readonly transaction 4 using stores `customers`
Cursor: openCursor request on index `name` (transaction 4, operation 0)
Cursor (event=success): Cursor value on index `name` (transaction 4, operation 0)
Cursor (event=success): Cursor value on index `name` (transaction 4, operation 0)
Cursor (event=success): Cursor value on index `name` (transaction 4, operation 0)
Cursor: Cursor closed on index `name` (transaction 4, operation 0)
Transaction (event=complete): Closed readonly transaction 4
Transaction: Opened readonly transaction 5 using stores `customers`
Query: count request on object store `customers` (transaction 5, operation 0)
Query (event=success): count response on object store `customers` (transaction 5, operation 0)
Transaction (event=complete): Closed readonly transaction 5
Transaction: Opened readonly transaction 6 using stores `customers`
Query: count request on index `age` (transaction 6, operation 0)
Query (event=success): count response on index `age` (transaction 6, operation 0)
Transaction (event=complete): Closed readonly transaction 6
Transaction: Opened readonly transaction 7 using stores `customers`
Cursor: openCursor request on index `age` (transaction 7, operation 0)
Cursor (event=success): Cursor value on index `age` (transaction 7, operation 0)
Cursor (event=success): Cursor value on index `age` (transaction 7, operation 0)
Cursor: Cursor closed on index `age` (transaction 7, operation 0)
Transaction (event=complete): Closed readonly transaction 7
Transaction: Opened readonly transaction 8 using stores `customers`
Cursor: openCursor request on index `age` (transaction 8, operation 0)
Cursor (event=success): Cursor value on index `age` (transaction 8, operation 0)
Cursor (event=success): Cursor value on index `age` (transaction 8, operation 0)
Cursor: Cursor closed on index `age` (transaction 8, operation 0)
Transaction (event=complete): Closed readonly transaction 8
Database: Closing database `your-database-name` due to explicit `close()`
Database: Closed database `your-database-name`
Database: Deleting database `your-database-name`
Database (event=success): Deleted database `your-database-name`
```
</details>
