### PR TITLE
Add support for transaction rollbacks

### DIFF
--- a/core/src/jsMain/kotlin/Transaction.kt
+++ b/core/src/jsMain/kotlin/Transaction.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import org.w3c.dom.events.Event
-import kotlin.js.Json
 
 public open class Transaction internal constructor(
     internal val transaction: IDBTransaction,

--- a/core/src/jsTest/kotlin/TransactionTest.kt
+++ b/core/src/jsTest/kotlin/TransactionTest.kt
@@ -1,0 +1,68 @@
+package com.juul.indexeddb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TransactionTest {
+    @Test
+    fun readWithinTransaction() = runTest {
+        val database = openDatabase("read-within-transaction", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", KeyPath("id"))
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("read-within-transaction")
+        }
+
+        val user = database.writeTransaction("users") {
+            objectStore("users").add(
+                jso {
+                    id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a"
+                    username = "Username"
+                },
+            )
+            objectStore("users")
+                .get(Key("7740f7c4-f889-498a-bc6d-f88dabdcfb9a"))
+        }
+
+        assertEquals("Username", user.username)
+    }
+
+    @Test
+    fun whenExceptionIsThrowWithinTransaction_transactionIsAborted() = runTest {
+        val database = openDatabase("abort-transaction", 1) { database, oldVersion, newVersion ->
+            if (oldVersion < 1) {
+                database.createObjectStore("users", KeyPath("id"))
+            }
+        }
+        onCleanup {
+            database.close()
+            deleteDatabase("abort-transaction")
+        }
+
+        assertFailsWith<ExceptionToAbortTransaction> {
+            database.writeTransaction("users") {
+                objectStore("users").add(
+                    jso {
+                        id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a"
+                        username = "Username"
+                    },
+                )
+
+                // Abort transaction
+                throw ExceptionToAbortTransaction()
+            }
+        }
+
+        // because transaction is aborted, new values shouldn't be stored
+        val users = database.transaction("users") {
+            objectStore("users").getAll().toList()
+        }
+
+        assertEquals(listOf(), users)
+    }
+}
+private class ExceptionToAbortTransaction : Exception()


### PR DESCRIPTION
**Hi, first of all, thanks for the great library! It made my life much easier! 🎉**

Previously, when an exception was thrown during a transaction, the changes were still applied to the database, even if the transaction was intended to be aborted.

For example, consider this code:

```kotlin
database.writeTransaction("users") {
    objectStore("users").add(
        jso {
            id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a"
            username = "Username"
        },
    )

    // Abort transaction
    throw Exception("An exception is returned, transaction should be aborted")
}
```

Even though an exception was thrown, the object would still be added to the database.

**With this change, if an exception is thrown during a transaction, all writes within that transaction are rolled back.**

Here's an example of how this works:

```kotlin
assertFailsWith<SomeException> {
    database.writeTransaction("users") {
        objectStore("users").add(
            jso {
                id = "7740f7c4-f889-498a-bc6d-f88dabdcfb9a"
                username = "Username"
            },
        )

        // Abort transaction
        throw SomeException()
    }
}

// Because the transaction is aborted, no new values should be stored
val users = database.transaction("users") {
    objectStore("users").getAll().toList()
}

assertEquals(listOf(), users)
```
