### PR TITLE
fix prevent rollback after commit

### DIFF
--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -151,7 +151,7 @@ public class Database internal constructor(
             // Force overlapping transactions to not call `action` until prior transactions complete.
             objectStore(store.first()).awaitTransaction()
         }
-        val result =  try {
+        val result = try {
             transaction.action()
         } catch (e: Throwable) {
             transaction.abort()

--- a/core/src/jsMain/kotlin/Database.kt
+++ b/core/src/jsMain/kotlin/Database.kt
@@ -151,18 +151,18 @@ public class Database internal constructor(
             // Force overlapping transactions to not call `action` until prior transactions complete.
             objectStore(store.first()).awaitTransaction()
         }
-        try {
-            val result = transaction.action()
-            transaction.commit()
-            transaction.awaitCompletion { event ->
-                logger.log(Type.Transaction, event) { "Closed readwrite transaction $id on database `$name`" }
-            }
-            result
+        val result =  try {
+            transaction.action()
         } catch (e: Throwable) {
             transaction.abort()
             transaction.awaitFailure()
             throw e
         }
+        transaction.commit()
+        transaction.awaitCompletion { event ->
+            logger.log(Type.Transaction, event) { "Closed readwrite transaction $id on database `$name`" }
+        }
+        result
     }
 
     public fun close() {


### PR DESCRIPTION
When an exception is thrown after the commit (due to a `CancellationException`), we must not call `transaction.abort()` because this is not allowed.

We are running into this error case in Firefox: https://github.com/mozilla/gecko-dev/blob/master/dom/indexedDB/IDBTransaction.cpp#L687